### PR TITLE
Move writeJUnitOutput to output.go

### DIFF
--- a/output.go
+++ b/output.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 )
 
@@ -128,5 +130,68 @@ func writeJSONOutput(data interface{}, filename string) error {
 	}
 
 	log.Printf("JSON output written to: %s", filename)
+	return nil
+}
+
+func writeJUnitOutput(scanResults ScanResults, filename string) error {
+	testSuite := JUnitTestSuite{
+		Name: "TLSSecurityScan",
+	}
+
+	for _, ipResult := range scanResults.IPResults {
+		for _, portResult := range ipResult.PortResults {
+			testCase := JUnitTestCase{
+				Name:      fmt.Sprintf("%s:%d - %s", ipResult.IP, portResult.Port, portResult.Service),
+				ClassName: ipResult.Pod.Name,
+			}
+
+			var failures []string
+			if portResult.IngressTLSConfigCompliance != nil && (!portResult.IngressTLSConfigCompliance.Version || !portResult.IngressTLSConfigCompliance.Ciphers) {
+				failures = append(failures, "Ingress TLS config is not compliant.")
+			}
+			if portResult.APIServerTLSConfigCompliance != nil && (!portResult.APIServerTLSConfigCompliance.Version || !portResult.APIServerTLSConfigCompliance.Ciphers) {
+				failures = append(failures, "API Server TLS config is not compliant.")
+			}
+			if portResult.KubeletTLSConfigCompliance != nil && (!portResult.KubeletTLSConfigCompliance.Version || !portResult.KubeletTLSConfigCompliance.Ciphers) {
+				failures = append(failures, "Kubelet TLS config is not compliant.")
+			}
+
+			if len(failures) > 0 {
+				testCase.Failure = &JUnitFailure{
+					Message: "TLS Compliance Failed",
+					Type:    "TLSComplianceCheck",
+					Content: strings.Join(failures, "\n"),
+				}
+				testSuite.Failures++
+			}
+
+			testSuite.TestCases = append(testSuite.TestCases, testCase)
+		}
+	}
+
+	testSuite.Tests = len(testSuite.TestCases)
+
+	// Create the directory for the file if it doesn't exist
+	dir := filepath.Dir(filename)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("could not create directory for JUnit report: %v", err)
+	}
+
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("could not create JUnit report file: %v", err)
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(xml.Header); err != nil {
+		return fmt.Errorf("failed to write XML header to JUnit report: %v", err)
+	}
+
+	encoder := xml.NewEncoder(file)
+	encoder.Indent("", "  ")
+	if err := encoder.Encode(testSuite); err != nil {
+		return fmt.Errorf("could not encode JUnit report: %v", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
We have a few other functions in output.go for writing reports in CSV or
JSON. Let's move the JUnit output function there too to simplify
main.go.
