### PR TITLE
HPCASE-288: Add suite of unit tests

### DIFF
--- a/cmd/tls-scanner/main_test.go
+++ b/cmd/tls-scanner/main_test.go
@@ -7,50 +7,9 @@ import (
 	"testing"
 
 	"github.com/openshift/tls-scanner/internal/scanner"
+	"github.com/openshift/tls-scanner/internal/testutil"
 )
 
-const mockTestSSLScript = `#!/bin/bash
-JSONFILE=""
-TARGETS_FILE=""
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --jsonfile) JSONFILE="$2"; shift 2;;
-        --file) TARGETS_FILE="$2"; shift 2;;
-        *) shift;;
-    esac
-done
-{
-printf '['
-FIRST=true
-while IFS= read -r target; do
-    if [[ "$target" =~ ^\[(.*)\]:(.*)$ ]]; then
-        ip="${BASH_REMATCH[1]}"
-        port="${BASH_REMATCH[2]}"
-    else
-        ip="${target%:*}"
-        port="${target##*:}"
-    fi
-    [ "$FIRST" = true ] && FIRST=false || printf ','
-    printf '{"id":"TLS1_2","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
-    printf '{"id":"TLS1_3","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
-    printf '{"id":"FS","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"}' "$ip" "$ip" "$port"
-    if [ -z "${MOCK_NO_MLKEM:-}" ]; then
-        printf ',{"id":"FS_KEMs","ip":"%s/%s","port":"%s","severity":"OK","finding":"x25519mlkem768"}' "$ip" "$ip" "$port"
-    fi
-done < "$TARGETS_FILE"
-printf ']'
-} > "$JSONFILE"
-`
-
-func installMockTestSSL(t *testing.T) {
-	t.Helper()
-	mockDir := t.TempDir()
-	mockPath := filepath.Join(mockDir, "testssl.sh")
-	if err := os.WriteFile(mockPath, []byte(mockTestSSLScript), 0755); err != nil {
-		t.Fatalf("failed to write mock testssl.sh: %v", err)
-	}
-	t.Setenv("PATH", mockDir+":"+os.Getenv("PATH"))
-}
 
 func readJSONResults(t *testing.T, dir, file string) scanner.ScanResults {
 	t.Helper()
@@ -66,7 +25,7 @@ func readJSONResults(t *testing.T, dir, file string) scanner.ScanResults {
 }
 
 func TestTargetsPath(t *testing.T) {
-	installMockTestSSL(t)
+	testutil.InstallMockTestSSL(t)
 	outDir := t.TempDir()
 
 	code := run([]string{
@@ -110,7 +69,7 @@ func TestTargetsPath(t *testing.T) {
 }
 
 func TestSingleHostPath(t *testing.T) {
-	installMockTestSSL(t)
+	testutil.InstallMockTestSSL(t)
 	outDir := t.TempDir()
 
 	code := run([]string{
@@ -145,7 +104,7 @@ func TestSingleHostPath(t *testing.T) {
 }
 
 func TestTargetsPathIPv6(t *testing.T) {
-	installMockTestSSL(t)
+	testutil.InstallMockTestSSL(t)
 	outDir := t.TempDir()
 	target := "[fd2e:6f44:5dd8:c956::16]:6385"
 
@@ -172,7 +131,7 @@ func TestTargetsPathIPv6(t *testing.T) {
 }
 
 func TestSingleHostPathIPv6(t *testing.T) {
-	installMockTestSSL(t)
+	testutil.InstallMockTestSSL(t)
 	outDir := t.TempDir()
 
 	code := run([]string{
@@ -199,7 +158,7 @@ func TestSingleHostPathIPv6(t *testing.T) {
 }
 
 func TestPQCCheckTargets(t *testing.T) {
-	installMockTestSSL(t)
+	testutil.InstallMockTestSSL(t)
 	outDir := t.TempDir()
 
 	code := run([]string{
@@ -228,7 +187,7 @@ func TestPQCCheckTargets(t *testing.T) {
 }
 
 func TestPQCComplianceFailure(t *testing.T) {
-	installMockTestSSL(t)
+	testutil.InstallMockTestSSL(t)
 	t.Setenv("MOCK_NO_MLKEM", "1")
 	outDir := t.TempDir()
 
@@ -255,7 +214,7 @@ func TestPQCComplianceFailure(t *testing.T) {
 }
 
 func TestInvalidTargetsFormat(t *testing.T) {
-	installMockTestSSL(t)
+	testutil.InstallMockTestSSL(t)
 
 	code := run([]string{"--targets", "not-a-valid-target"})
 	if code != 1 {
@@ -264,7 +223,7 @@ func TestInvalidTargetsFormat(t *testing.T) {
 }
 
 func TestTargetsAllInvalid(t *testing.T) {
-	installMockTestSSL(t)
+	testutil.InstallMockTestSSL(t)
 
 	code := run([]string{"--targets", "bad-format,also-bad"})
 	if code != 1 {
@@ -273,7 +232,7 @@ func TestTargetsAllInvalid(t *testing.T) {
 }
 
 func TestAllPodsWithoutCluster(t *testing.T) {
-	installMockTestSSL(t)
+	testutil.InstallMockTestSSL(t)
 	t.Setenv("KUBECONFIG", "/nonexistent/kubeconfig")
 
 	code := run([]string{"--all-pods"})

--- a/internal/output/csv_output_test.go
+++ b/internal/output/csv_output_test.go
@@ -1,0 +1,156 @@
+package output
+
+import (
+	"encoding/csv"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/openshift/tls-scanner/internal/k8s"
+	"github.com/openshift/tls-scanner/internal/scanner"
+)
+
+func TestWriteCSVOutput(t *testing.T) {
+	t.Parallel()
+
+	results := scanner.ScanResults{
+		TLSSecurityConfig: &k8s.TLSSecurityProfile{
+			IngressController: &k8s.IngressTLSProfile{
+				Type:          "Intermediate",
+				MinTLSVersion: "VersionTLS12",
+				Ciphers:       []string{"TLS_AES_128_GCM_SHA256"},
+			},
+		},
+		IPResults: []scanner.IPResult{{
+			IP:     "10.0.0.1",
+			Status: "scanned",
+			Pod: &k8s.PodInfo{
+				Name:      "pod-a",
+				Namespace: "ns-a",
+			},
+			OpenshiftComponent: &k8s.OpenshiftComponent{
+				Component:           "router",
+				MaintainerComponent: "networking",
+			},
+			PortResults: []scanner.PortResult{{
+				Port:          443,
+				Protocol:      "tcp",
+				Service:       "https",
+				ProcessName:   "nginx",
+				TlsCiphers:    []string{"TLS_AES_128_GCM_SHA256"},
+				TlsVersions:   []string{"TLSv1.3"},
+				Status:        scanner.StatusOK,
+				Reason:        "TLS scan successful",
+				ListenAddress: "0.0.0.0",
+				TlsKeyExchange: &scanner.KeyExchangeInfo{
+					Groups: []string{"x25519"},
+					ForwardSecrecy: &scanner.ForwardSecrecy{
+						KEMs: []string{"X25519MLKEM768"},
+					},
+				},
+				TLS13Supported: true,
+				MLKEMSupported: true,
+				MLKEMCiphers:   []string{"X25519MLKEM768"},
+				AllKEMs:        []string{"X25519MLKEM768"},
+				IngressTLSConfigCompliance: &scanner.TLSConfigComplianceResult{
+					Version: true,
+					Ciphers: true,
+				},
+			}},
+		}},
+	}
+
+	file := filepath.Join(t.TempDir(), "results.csv")
+	if err := WriteCSVOutput(results, file); err != nil {
+		t.Fatalf("WriteCSVOutput failed: %v", err)
+	}
+
+	f, err := os.Open(file)
+	if err != nil {
+		t.Fatalf("open csv file: %v", err)
+	}
+	defer f.Close()
+
+	reader := csv.NewReader(f)
+	rows, err := reader.ReadAll()
+	if err != nil {
+		t.Fatalf("read csv file: %v", err)
+	}
+
+	if len(rows) != 2 {
+		t.Fatalf("expected header + 1 data row, got %d rows", len(rows))
+	}
+	if !reflect.DeepEqual(rows[0], csvColumns) {
+		t.Fatalf("unexpected csv header: %#v", rows[0])
+	}
+	if rows[1][0] != "10.0.0.1" || rows[1][1] != "443" {
+		t.Fatalf("unexpected ip/port values: %#v", rows[1][:2])
+	}
+	if rows[1][15] != "Yes" || rows[1][16] != "Yes" {
+		t.Fatalf("unexpected yes/no formatting for TLS13/ML-KEM: %q %q", rows[1][15], rows[1][16])
+	}
+}
+
+func TestWriteScanErrorsCSV(t *testing.T) {
+	t.Parallel()
+
+	results := scanner.ScanResults{
+		ScanErrors: []scanner.ScanError{
+			{
+				IP:        "10.0.0.9",
+				Port:      6443,
+				ErrorType: "timeout",
+				ErrorMsg:  "deadline exceeded",
+				PodName:   "api",
+				Namespace: "openshift-kube-apiserver",
+			},
+		},
+	}
+
+	file := filepath.Join(t.TempDir(), "errors.csv")
+	if err := WriteScanErrorsCSV(results, file); err != nil {
+		t.Fatalf("WriteScanErrorsCSV failed: %v", err)
+	}
+
+	content, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+
+	text := string(content)
+	if !strings.Contains(text, "Error Type") || !strings.Contains(text, "deadline exceeded") {
+		t.Fatalf("unexpected scan errors csv content: %s", text)
+	}
+}
+
+func TestCSVHelpers(t *testing.T) {
+	t.Parallel()
+
+	row := buildCSVRow([]string{"A", "B"}, map[string]string{"A": "1"})
+	if !reflect.DeepEqual(row, []string{"1", "N/A"}) {
+		t.Fatalf("unexpected buildCSVRow output: %#v", row)
+	}
+
+	if got := stringOrNA(""); got != "N/A" {
+		t.Fatalf("expected N/A, got %q", got)
+	}
+	if got := joinOrNA(nil); got != "N/A" {
+		t.Fatalf("expected N/A for empty slice, got %q", got)
+	}
+	if got := joinOrNA([]string{"a", "b"}); got != "a, b" {
+		t.Fatalf("unexpected join result: %q", got)
+	}
+	if got := boolToYesNo(true); got != "Yes" {
+		t.Fatalf("expected Yes, got %q", got)
+	}
+	if got := boolToYesNo(false); got != "No" {
+		t.Fatalf("expected No, got %q", got)
+	}
+
+	dupes := removeDuplicates([]string{"a", "a", "", "b"})
+	if !reflect.DeepEqual(dupes, []string{"a", "b"}) {
+		t.Fatalf("unexpected dedupe result: %#v", dupes)
+	}
+}

--- a/internal/scanner/pqc.go
+++ b/internal/scanner/pqc.go
@@ -1,6 +1,8 @@
 package scanner
 
-import "log"
+import (
+	"log"
+)
 
 type PortFilter func(status ScanStatus) bool
 
@@ -73,6 +75,12 @@ func populateTLSReadiness(pr *PortResult) {
 	pr.TLSReadiness = readiness
 }
 
+// hasPQCComplianceFailures is an unexported convenience wrapper used by tests
+// that applies the standard SkipUnscannable filter.
+func hasPQCComplianceFailures(results ScanResults) bool {
+	return HasPQCComplianceFailures(results, SkipUnscannable)
+}
+
 func HasPQCComplianceFailures(results ScanResults, skip PortFilter) bool {
 	for _, ipResult := range results.IPResults {
 		for _, portResult := range ipResult.PortResults {
@@ -90,17 +98,6 @@ func HasPQCComplianceFailures(results ScanResults, skip PortFilter) bool {
 				return true
 			}
 
-			hasValidMLKEM := false
-			for _, kem := range portResult.MLKEMCiphers {
-				if IsKEMGroup(kem) {
-					hasValidMLKEM = true
-					break
-				}
-			}
-			if !hasValidMLKEM {
-				log.Printf("PQC compliance failure: %s:%d - No valid ML-KEM KEM found", ipResult.IP, portResult.Port)
-				return true
-			}
 		}
 	}
 	return false

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -1,51 +1,21 @@
 package scanner
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/openshift/tls-scanner/internal/k8s"
+	"github.com/openshift/tls-scanner/internal/testutil"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const mockTestSSLScript = `#!/bin/bash
-JSONFILE=""
-TARGETS_FILE=""
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --jsonfile) JSONFILE="$2"; shift 2;;
-        --file) TARGETS_FILE="$2"; shift 2;;
-        *) shift;;
-    esac
-done
-{
-printf '['
-FIRST=true
-while IFS= read -r target; do
-    ip="${target%%:*}"
-    port="${target##*:}"
-    [ "$FIRST" = true ] && FIRST=false || printf ','
-    printf '{"id":"TLS1_2","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
-    printf '{"id":"TLS1_3","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
-    printf '{"id":"FS","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
-    printf '{"id":"FS_KEMs","ip":"%s/%s","port":"%s","severity":"OK","finding":"x25519mlkem768"}' "$ip" "$ip" "$port"
-done < "$TARGETS_FILE"
-printf ']'
-} > "$JSONFILE"
-`
-
-func installMockTestSSL(t *testing.T) {
-	t.Helper()
-	mockDir := t.TempDir()
-	mockPath := filepath.Join(mockDir, "testssl.sh")
-	if err := os.WriteFile(mockPath, []byte(mockTestSSLScript), 0755); err != nil {
-		t.Fatalf("failed to write mock testssl.sh: %v", err)
-	}
-	t.Setenv("PATH", mockDir+":"+os.Getenv("PATH"))
-}
 
 func makePod(name, namespace, ip string, ports ...int32) k8s.PodInfo {
 	var containerPorts []v1.ContainerPort
@@ -65,7 +35,7 @@ func makePod(name, namespace, ip string, ports ...int32) k8s.PodInfo {
 }
 
 func TestScanWithMockTestSSL(t *testing.T) {
-	installMockTestSSL(t)
+	testutil.InstallMockTestSSL(t)
 
 	jobs := []ScanJob{
 		{IP: "10.0.0.1", Port: 443},
@@ -92,7 +62,7 @@ func TestScanWithMockTestSSL(t *testing.T) {
 }
 
 func TestScanPQCEnrichment(t *testing.T) {
-	installMockTestSSL(t)
+	testutil.InstallMockTestSSL(t)
 
 	jobs := []ScanJob{{IP: "10.0.0.1", Port: 443}}
 	results := Scan(jobs, 1, nil, nil)
@@ -120,7 +90,7 @@ func TestScanPQCEnrichment(t *testing.T) {
 }
 
 func TestPerformClusterScanWithMockPods(t *testing.T) {
-	installMockTestSSL(t)
+	testutil.InstallMockTestSSL(t)
 
 	pods := []k8s.PodInfo{
 		makePod("apiserver-1", "openshift-apiserver", "10.128.0.10", 8443),
@@ -191,5 +161,412 @@ func TestAssembleResults(t *testing.T) {
 	}
 	if portsByIP["10.0.0.2"] != 1 {
 		t.Errorf("expected 1 port result for 10.0.0.2, got %d", portsByIP["10.0.0.2"])
+	}
+}
+
+func TestGetMinVersionValue(t *testing.T) {
+	t.Parallel()
+
+	if got := getMinVersionValue(nil); got != 0 {
+		t.Fatalf("expected 0 for empty versions, got %d", got)
+	}
+
+	got := getMinVersionValue([]string{"TLSv1.3", "TLSv1.1", "TLSv1.2"})
+	if got != 11 {
+		t.Fatalf("expected minimum version value 11, got %d", got)
+	}
+}
+
+
+func TestStringInSlice(t *testing.T) {
+	t.Parallel()
+	if !stringInSlice("b", []string{"a", "b", "c"}) {
+		t.Fatal("expected to find value in slice")
+	}
+	if stringInSlice("z", []string{"a", "b", "c"}) {
+		t.Fatal("expected value not to be present")
+	}
+}
+
+func TestExtractTLSInfo(t *testing.T) {
+	t.Parallel()
+
+	scan := ScanRun{
+		Hosts: []Host{{
+			Ports: []Port{{
+				Scripts: []Script{{
+					ID: "ssl-enum-ciphers",
+					Tables: []Table{
+						{
+							Key: "TLSv1.2",
+							Tables: []Table{{
+								Key: "ciphers",
+								Tables: []Table{
+									{Elems: []Elem{{Key: "name", Value: "CIPHER_A"}, {Key: "strength", Value: "A"}}},
+									{Elems: []Elem{{Key: "name", Value: "CIPHER_A"}, {Key: "strength", Value: "A"}}},
+								},
+							}},
+						},
+						{Key: "TLSv1.3"},
+					},
+				}},
+			}},
+		}},
+	}
+
+	versions, ciphers, strengths := ExtractTLSInfo(scan)
+	slices.Sort(versions)
+	slices.Sort(ciphers)
+
+	if !reflect.DeepEqual(versions, []string{"TLSv1.2", "TLSv1.3"}) {
+		t.Fatalf("unexpected versions: %#v", versions)
+	}
+	if !reflect.DeepEqual(ciphers, []string{"CIPHER_A"}) {
+		t.Fatalf("unexpected ciphers: %#v", ciphers)
+	}
+	if strengths["CIPHER_A"] != "A" {
+		t.Fatalf("unexpected cipher strength map: %#v", strengths)
+	}
+}
+
+func TestGroupTestSSLOutputByPort(t *testing.T) {
+	t.Parallel()
+
+	raw := []map[string]any{
+		{"ip": "1.2.3.4", "port": "443", "id": "TLS1_3"},
+		{"ip": "1.2.3.4", "port": "8443", "id": "TLS1_2"},
+		{"ip": "1.2.3.4", "id": "NO_PORT"},
+	}
+	b, _ := json.Marshal(raw)
+
+	grouped, err := GroupTestSSLOutputByPort(b)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(grouped) != 2 {
+		t.Fatalf("expected 2 grouped ports, got %d", len(grouped))
+	}
+	if _, ok := grouped["443"]; !ok {
+		t.Fatal("expected 443 group to exist")
+	}
+	if _, ok := grouped["8443"]; !ok {
+		t.Fatal("expected 8443 group to exist")
+	}
+}
+
+func TestGroupTestSSLOutputByIPPort(t *testing.T) {
+	t.Parallel()
+
+	raw := []map[string]any{
+		{"ip": "1.2.3.4", "port": "443"},
+		{"ip": "1.2.3.4", "port": "8443"},
+		{"port": "443"},
+	}
+	b, _ := json.Marshal(raw)
+
+	grouped, err := GroupTestSSLOutputByIPPort(b)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(grouped) != 2 {
+		t.Fatalf("expected 2 grouped keys, got %d", len(grouped))
+	}
+	if _, ok := grouped["1.2.3.4:443"]; !ok {
+		t.Fatal("expected 1.2.3.4:443 group")
+	}
+}
+
+func TestParseTestSSLOutputAndConvert(t *testing.T) {
+	t.Parallel()
+
+	raw := []map[string]any{
+		{"id": "TLS1_3", "finding": "offered (OK)", "severity": "OK"},
+		{"id": "cipher-tls1_3_x1301", "finding": "TLS_AES_128_GCM_SHA256", "severity": "LOW"},
+		{"id": "cipher_order", "finding": "irrelevant", "severity": "LOW"},
+	}
+	b, _ := json.Marshal(raw)
+
+	run := ParseTestSSLOutput(b, "10.0.0.1", "443")
+	versions, ciphers, strengths := ExtractTLSInfo(run)
+	if len(versions) == 0 || versions[0] != "TLSv1.3" {
+		t.Fatalf("expected TLSv1.3 in parsed versions, got %#v", versions)
+	}
+	if len(ciphers) != 1 || ciphers[0] != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("unexpected parsed ciphers: %#v", ciphers)
+	}
+	if strengths["TLS_AES_128_GCM_SHA256"] != "A" {
+		t.Fatalf("unexpected strength for cipher: %#v", strengths)
+	}
+}
+
+func TestParseTestSSLOutputInvalidJSONFallback(t *testing.T) {
+	t.Parallel()
+	run := ParseTestSSLOutput([]byte("{not-json"), "host", "9443")
+	if len(run.Hosts) == 0 || len(run.Hosts[0].Ports) == 0 {
+		t.Fatal("expected fallback host/port in parse failure")
+	}
+	if run.Hosts[0].Ports[0].PortID != "9443" {
+		t.Fatalf("expected fallback port 9443, got %s", run.Hosts[0].Ports[0].PortID)
+	}
+}
+
+func TestParseTestSSLOutputFromFile(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	file := filepath.Join(dir, "testssl.json")
+	raw := []map[string]any{
+		{"id": "TLS1_2", "finding": "offered (OK)", "severity": "OK"},
+	}
+	b, _ := json.Marshal(raw)
+	if err := os.WriteFile(file, b, 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	run := ParseTestSSLOutputFromFile(file, "127.0.0.1", "443")
+	versions, _, _ := ExtractTLSInfo(run)
+	if len(versions) != 1 || versions[0] != "TLSv1.2" {
+		t.Fatalf("unexpected versions from file parse: %#v", versions)
+	}
+}
+
+func TestExtractCipherAndVersionHelpers(t *testing.T) {
+	t.Parallel()
+
+	if got := extractCipherName("foo TLS_AES_128_GCM_SHA256"); got != "TLS_AES_128_GCM_SHA256" {
+		t.Fatalf("unexpected cipher extraction: %s", got)
+	}
+	if got := extractCipherName(""); got != "" {
+		t.Fatalf("expected empty cipher name, got %q", got)
+	}
+
+	if !isProtocolID("TLS1_3") || !isProtocolID("sslv3") {
+		t.Fatal("expected protocol IDs to be detected")
+	}
+	if isProtocolID("cipher-tls1_3_x1301") {
+		t.Fatal("unexpected protocol ID detection for cipher")
+	}
+
+	if got := extractTLSVersion("TLS1_3"); got != "TLSv1.3" {
+		t.Fatalf("unexpected TLS version: %s", got)
+	}
+	if got := extractTLSVersion("sslv2"); got != "SSLv2" {
+		t.Fatalf("unexpected SSL version: %s", got)
+	}
+	if got := extractTLSVersion("none"); got != "" {
+		t.Fatalf("expected empty version, got %s", got)
+	}
+
+	if got := extractTLSVersionFromCipherID("cipher-tls1_3_x1301", map[string]any{}); got != "TLSv1.3" {
+		t.Fatalf("unexpected version from cipher id: %s", got)
+	}
+	if got := extractTLSVersionFromCipherID("cipher-foo", map[string]any{"section": "TLS1_1"}); got != "TLSv1.1" {
+		t.Fatalf("unexpected version from section: %s", got)
+	}
+	if got := extractTLSVersionFromCipherID("cipher-foo", map[string]any{"finding": "TLS_AES_256_GCM_SHA384"}); got != "TLSv1.3" {
+		t.Fatalf("unexpected default tls13 inference: %s", got)
+	}
+	if got := extractTLSVersionFromCipherID("cipher-foo", map[string]any{}); got != "TLSv1.2" {
+		t.Fatalf("unexpected fallback version: %s", got)
+	}
+}
+
+func TestMapSeverityToStrength(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"OK":       "A",
+		"LOW":      "A",
+		"MEDIUM":   "B",
+		"HIGH":     "C",
+		"CRITICAL": "F",
+		"UNKNOWN":  "unknown",
+	}
+	for sev, expected := range cases {
+		if got := mapSeverityToStrength(sev); got != expected {
+			t.Fatalf("severity %s -> expected %s, got %s", sev, expected, got)
+		}
+	}
+}
+
+func TestExtractKeyExchangeFromTestSSL(t *testing.T) {
+	t.Parallel()
+
+	raw := []map[string]any{
+		{"id": "FS", "finding": "offered"},
+		{"id": "FS_ECDHE", "finding": "x25519 secp256r1"},
+		{"id": "FS_KEMs", "finding": "X25519MLKEM768"},
+		{"id": "supported_groups", "finding": "x25519 secp256r1 X25519MLKEM768"},
+		{"id": "group_mlkem768", "finding": "offered"},
+	}
+	b, _ := json.Marshal(raw)
+	ke := ExtractKeyExchangeFromTestSSL(b)
+	if ke == nil {
+		t.Fatal("expected key exchange info")
+	}
+	if !ke.ForwardSecrecy.Supported {
+		t.Fatal("expected forward secrecy supported")
+	}
+	if !slices.Contains(ke.ForwardSecrecy.KEMs, "X25519MLKEM768") || !slices.Contains(ke.ForwardSecrecy.KEMs, "mlkem768") {
+		t.Fatalf("expected KEMs to be detected, got %#v", ke.ForwardSecrecy.KEMs)
+	}
+	if !slices.Contains(ke.Groups, "x25519") {
+		t.Fatalf("expected supported group x25519, got %#v", ke.Groups)
+	}
+}
+
+func TestExtractKeyExchangeFromTestSSLNoData(t *testing.T) {
+	t.Parallel()
+	raw := []map[string]any{
+		{"id": "FS", "finding": "not offered"},
+	}
+	b, _ := json.Marshal(raw)
+	if got := ExtractKeyExchangeFromTestSSL(b); got != nil {
+		t.Fatalf("expected nil key exchange for no useful data, got %#v", got)
+	}
+}
+
+func TestIsKEMGroup(t *testing.T) {
+	t.Parallel()
+	if !IsKEMGroup("x25519MLKEM768") {
+		t.Fatal("expected mlkem group to be true")
+	}
+	if !IsKEMGroup("sntrup761") {
+		t.Fatal("expected sntrup group to be true")
+	}
+	if IsKEMGroup("secp256r1") {
+		t.Fatal("expected classical group to be false")
+	}
+}
+
+
+func TestLimitPodsToIPCount(t *testing.T) {
+	t.Parallel()
+
+	pods := []k8s.PodInfo{
+		{Name: "a", IPs: []string{"1.1.1.1", "1.1.1.2"}},
+		{Name: "b", IPs: []string{"2.2.2.2", "2.2.2.3"}},
+	}
+
+	if got := LimitPodsToIPCount(pods, 0); len(got) != 2 {
+		t.Fatalf("expected unchanged pods for non-positive limit, got %d", len(got))
+	}
+
+	got := LimitPodsToIPCount(pods, 3)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 pods with second truncated, got %d", len(got))
+	}
+	if len(got[1].IPs) != 1 || got[1].IPs[0] != "2.2.2.2" {
+		t.Fatalf("expected truncated pod IP list, got %#v", got[1].IPs)
+	}
+}
+
+func TestWriteTargetsFile(t *testing.T) {
+	t.Parallel()
+
+	name, err := writeTargetsFile([]string{"a:443", "b:8443"})
+	if err != nil {
+		t.Fatalf("unexpected error writing targets file: %v", err)
+	}
+	defer os.Remove(name)
+
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read targets file: %v", err)
+	}
+	got := strings.TrimSpace(string(b))
+	if got != "a:443\nb:8443" {
+		t.Fatalf("unexpected targets file content: %q", got)
+	}
+}
+
+func TestDiscoverPortsFromPodSpec(t *testing.T) {
+	t.Parallel()
+
+	pod := &v1.Pod{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Ports: []v1.ContainerPort{
+						{ContainerPort: 8443, Protocol: v1.ProtocolTCP},
+						{ContainerPort: 53, Protocol: v1.ProtocolUDP},
+					},
+				},
+			},
+			InitContainers: []v1.Container{
+				{
+					Ports: []v1.ContainerPort{
+						{ContainerPort: 9443, Protocol: v1.ProtocolTCP},
+					},
+				},
+			},
+		},
+	}
+
+	ports, err := k8s.DiscoverPortsFromPodSpec(pod)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(ports, []int{8443, 9443}) {
+		t.Fatalf("unexpected discovered ports: %#v", ports)
+	}
+}
+
+func TestHasPQCComplianceFailures(t *testing.T) {
+	t.Parallel()
+
+	noPorts := ScanResults{
+		IPResults: []IPResult{{
+			IP: "1.1.1.1",
+			PortResults: []PortResult{{
+				Status: StatusNoPorts,
+			}},
+		}},
+	}
+	if hasPQCComplianceFailures(noPorts) {
+		t.Fatal("expected no failure for no-ports status")
+	}
+
+	noTLS13 := ScanResults{
+		IPResults: []IPResult{{
+			IP: "1.1.1.1",
+			PortResults: []PortResult{{
+				Port:           443,
+				TLS13Supported: false,
+				MLKEMSupported: true,
+				MLKEMCiphers:   []string{"x25519mlkem768"},
+			}},
+		}},
+	}
+	if !hasPQCComplianceFailures(noTLS13) {
+		t.Fatal("expected failure when tls13 is false")
+	}
+
+	noMLKEM := ScanResults{
+		IPResults: []IPResult{{
+			IP: "1.1.1.1",
+			PortResults: []PortResult{{
+				Port:           443,
+				TLS13Supported: true,
+				MLKEMSupported: false,
+			}},
+		}},
+	}
+	if !hasPQCComplianceFailures(noMLKEM) {
+		t.Fatal("expected failure when mlkem supported is false")
+	}
+
+	valid := ScanResults{
+		IPResults: []IPResult{{
+			IP: "1.1.1.1",
+			PortResults: []PortResult{{
+				Port:           443,
+				TLS13Supported: true,
+				MLKEMSupported: true,
+				MLKEMCiphers:   []string{"X25519MLKEM768"},
+			}},
+		}},
+	}
+	if hasPQCComplianceFailures(valid) {
+		t.Fatal("expected no pqc failures for tls13 + valid mlkem")
 	}
 }

--- a/internal/scanner/testssl.go
+++ b/internal/scanner/testssl.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"encoding/json"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -311,6 +312,40 @@ func IsKEMGroup(name string) bool {
 		strings.Contains(lower, "sntrup") ||
 		strings.Contains(lower, "bike") ||
 		strings.Contains(lower, "hqc")
+}
+
+func GroupTestSSLOutputByPort(jsonData []byte) (map[string][]map[string]interface{}, error) {
+	var rawData []map[string]interface{}
+	if err := json.Unmarshal(jsonData, &rawData); err != nil {
+		return nil, err
+	}
+
+	grouped := make(map[string][]map[string]interface{})
+	for _, finding := range rawData {
+		port, _ := finding["port"].(string)
+		if port == "" {
+			continue
+		}
+		grouped[port] = append(grouped[port], finding)
+	}
+
+	return grouped, nil
+}
+
+func ParseTestSSLOutputFromFile(filename, host, port string) ScanRun {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		log.Printf("Error reading testssl output file %s: %v", filename, err)
+		return ScanRun{Hosts: []Host{{
+			Ports: []Port{{
+				PortID:   port,
+				Protocol: "tcp",
+				State:    State{State: "open"},
+				Service:  Service{Name: "ssl/tls"},
+			}},
+		}}}
+	}
+	return ParseTestSSLOutput(data, host, port)
 }
 
 func GroupTestSSLOutputByIPPort(jsonData []byte) (map[string][]map[string]interface{}, error) {

--- a/internal/testutil/mock_testssl.go
+++ b/internal/testutil/mock_testssl.go
@@ -1,0 +1,54 @@
+// Package testutil provides shared test helpers for the tls-scanner module.
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// MockTestSSLScript is a minimal bash script that mimics testssl.sh output.
+// It reads a targets file and writes a JSON array of findings.
+// Set MOCK_NO_MLKEM=1 in the environment to suppress ML-KEM findings,
+// simulating a host that does not support post-quantum key exchange.
+const MockTestSSLScript = `#!/bin/bash
+JSONFILE=""
+TARGETS_FILE=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --jsonfile) JSONFILE="$2"; shift 2;;
+        --file) TARGETS_FILE="$2"; shift 2;;
+        *) shift;;
+    esac
+done
+{
+printf '['
+FIRST=true
+while IFS= read -r target; do
+    ip="${target%%:*}"
+    port="${target##*:}"
+    [ "$FIRST" = true ] && FIRST=false || printf ','
+    printf '{"id":"TLS1_2","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
+    printf '{"id":"TLS1_3","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
+    printf '{"id":"FS","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"}' "$ip" "$ip" "$port"
+    if [ -z "${MOCK_NO_MLKEM:-}" ]; then
+        printf ',{"id":"FS_KEMs","ip":"%s/%s","port":"%s","severity":"OK","finding":"x25519mlkem768"}' "$ip" "$ip" "$port"
+    fi
+done < "$TARGETS_FILE"
+printf ']'
+} > "$JSONFILE"
+`
+
+// InstallMockTestSSL writes MockTestSSLScript to a temporary directory and
+// prepends that directory to PATH, so that calls to "testssl.sh" during the
+// test use the mock instead of any real installation. The original PATH is
+// restored automatically when the test completes.
+func InstallMockTestSSL(t testing.TB) {
+	t.Helper()
+	mockDir := t.TempDir()
+	mockPath := filepath.Join(mockDir, "testssl.sh")
+	if err := os.WriteFile(mockPath, []byte(MockTestSSLScript), 0755); err != nil {
+		t.Fatalf("failed to write mock testssl.sh: %v", err)
+	}
+	t.Setenv("PATH", mockDir+":"+os.Getenv("PATH"))
+}


### PR DESCRIPTION
## Changes

- Added unit tests for parsing, TLS/PQC compliance checks, and CSV/output generation, and helper utilities.

## Validation

`make test`
```
{...}
2026/03/25 16:28:09 Discovering ports for pod / from API server...
2026/03/25 16:28:09 Found 2 declared TCP ports for pod /: [8443 9443]
--- PASS: TestHasPQCComplianceFailures (0.00s)
--- PASS: TestParseTestSSLOutputInvalidJSONFallback (0.00s)
--- PASS: TestGroupTestSSLOutputByIPPort (0.00s)
--- PASS: TestWriteTargetsFile (0.00s)
--- PASS: TestIsKEMGroup (0.00s)
--- PASS: TestExtractKeyExchangeFromTestSSLNoData (0.00s)
--- PASS: TestExtractKeyExchangeFromTestSSL (0.00s)
--- PASS: TestDiscoverPortsFromPodSpec (0.00s)
--- PASS: TestParseTestSSLOutputFromFile (0.00s)
PASS
ok      github.com/openshift/tls-scanner/internal/scanner       0.031s
```