### PR TITLE
HPCASE-296: Add ipv6 support

### DIFF
--- a/cmd/tls-scanner/main.go
+++ b/cmd/tls-scanner/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -131,17 +132,12 @@ func run(args []string) (exitCode int) {
 
 		var jobs []scanner.ScanJob
 		for _, t := range targetList {
-			parts := strings.Split(t, ":")
-			if len(parts) != 2 {
+			hostValue, portValue, err := parseTarget(t)
+			if err != nil {
 				log.Printf("Warning: Skipping invalid target format: %s (expected host:port)", t)
 				continue
 			}
-			p, err := strconv.Atoi(parts[1])
-			if err != nil {
-				log.Printf("Warning: Skipping invalid port: %s", parts[1])
-				continue
-			}
-			jobs = append(jobs, scanner.ScanJob{IP: parts[0], Port: p})
+			jobs = append(jobs, scanner.ScanJob{IP: hostValue, Port: portValue})
 		}
 
 		if len(jobs) == 0 {
@@ -219,7 +215,7 @@ func run(args []string) (exitCode int) {
 		return 1
 	}
 
-	jobs := []scanner.ScanJob{{IP: *host, Port: portNum}}
+	jobs := []scanner.ScanJob{{IP: normalizeHost(*host), Port: portNum}}
 	scanResults := scanner.Scan(jobs, *concurrentScans, client, nil)
 	finalScanResults = &scanResults
 
@@ -234,4 +230,42 @@ func run(args []string) (exitCode int) {
 	}
 
 	return
+}
+
+func parseTarget(target string) (string, int, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return "", 0, fmt.Errorf("empty target")
+	}
+
+	host, port, err := net.SplitHostPort(target)
+	if err != nil {
+		// Support unbracketed IPv6 targets by splitting on the last colon.
+		// Example: fd2e:6f44:5dd8:c956::16:6385
+		if strings.Count(target, ":") > 1 && !strings.HasPrefix(target, "[") {
+			idx := strings.LastIndex(target, ":")
+			if idx <= 0 || idx >= len(target)-1 {
+				return "", 0, err
+			}
+			host = target[:idx]
+			port = target[idx+1:]
+		} else {
+			return "", 0, err
+		}
+	}
+
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return normalizeHost(host), portNum, nil
+}
+
+func normalizeHost(host string) string {
+	host = strings.TrimSpace(host)
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") && len(host) >= 2 {
+		return host[1 : len(host)-1]
+	}
+	return host
 }

--- a/cmd/tls-scanner/main_test.go
+++ b/cmd/tls-scanner/main_test.go
@@ -23,8 +23,13 @@ done
 printf '['
 FIRST=true
 while IFS= read -r target; do
-    ip="${target%%:*}"
-    port="${target##*:}"
+    if [[ "$target" =~ ^\[(.*)\]:(.*)$ ]]; then
+        ip="${BASH_REMATCH[1]}"
+        port="${BASH_REMATCH[2]}"
+    else
+        ip="${target%:*}"
+        port="${target##*:}"
+    fi
     [ "$FIRST" = true ] && FIRST=false || printf ','
     printf '{"id":"TLS1_2","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
     printf '{"id":"TLS1_3","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
@@ -136,6 +141,60 @@ func TestSingleHostPath(t *testing.T) {
 	pr := ir.PortResults[0]
 	if pr.Port != 8443 {
 		t.Errorf("expected port 8443, got %d", pr.Port)
+	}
+}
+
+func TestTargetsPathIPv6(t *testing.T) {
+	installMockTestSSL(t)
+	outDir := t.TempDir()
+	target := "[fd2e:6f44:5dd8:c956::16]:6385"
+
+	code := run([]string{
+		"--targets", target,
+		"--json-file", "results.json",
+		"--artifact-dir", outDir,
+		"-j", "1",
+	})
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d", code)
+	}
+
+	results := readJSONResults(t, outDir, "results.json")
+	if results.ScannedIPs != 1 {
+		t.Fatalf("expected 1 scanned IP, got %d", results.ScannedIPs)
+	}
+	if len(results.IPResults) == 0 {
+		t.Fatal("no IP results")
+	}
+	if results.IPResults[0].IP != "fd2e:6f44:5dd8:c956::16" {
+		t.Fatalf("expected IPv6 result, got %s", results.IPResults[0].IP)
+	}
+}
+
+func TestSingleHostPathIPv6(t *testing.T) {
+	installMockTestSSL(t)
+	outDir := t.TempDir()
+
+	code := run([]string{
+		"--host", "fd2e:6f44:5dd8:c956::16",
+		"--port", "6385",
+		"--json-file", "results.json",
+		"--artifact-dir", outDir,
+		"-j", "1",
+	})
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d", code)
+	}
+
+	results := readJSONResults(t, outDir, "results.json")
+	if results.ScannedIPs != 1 {
+		t.Fatalf("expected 1 scanned IP, got %d", results.ScannedIPs)
+	}
+	if len(results.IPResults) == 0 {
+		t.Fatal("no IP results")
+	}
+	if results.IPResults[0].IP != "fd2e:6f44:5dd8:c956::16" {
+		t.Fatalf("expected IPv6 result, got %s", results.IPResults[0].IP)
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"net"
 	"os"
 	"os/exec"
 	"strconv"
@@ -228,7 +229,7 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 	jobIndex := make(map[string]ScanJob, len(jobs))
 	targets := make([]string, 0, len(jobs))
 	for _, job := range jobs {
-		key := fmt.Sprintf("%s:%d", job.IP, job.Port)
+		key := targetKey(job.IP, strconv.Itoa(job.Port))
 		jobIndex[key] = job
 		targets = append(targets, key)
 	}
@@ -461,7 +462,7 @@ func deduplicateScanJobs(jobs []ScanJob) []ScanJob {
 	seen := make(map[string]bool, len(jobs))
 	var unique []ScanJob
 	for _, job := range jobs {
-		key := fmt.Sprintf("%s:%d", job.IP, job.Port)
+		key := targetKey(job.IP, strconv.Itoa(job.Port))
 		if seen[key] {
 			continue
 		}
@@ -481,4 +482,16 @@ func writeTargetsFile(targets []string) (string, error) {
 	}
 	f.Close()
 	return f.Name(), nil
+}
+
+func targetKey(host, port string) string {
+	return net.JoinHostPort(normalizeTargetHost(host), port)
+}
+
+func normalizeTargetHost(host string) string {
+	host = strings.TrimSpace(host)
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") && len(host) >= 2 {
+		return host[1 : len(host)-1]
+	}
+	return host
 }

--- a/internal/scanner/testssl.go
+++ b/internal/scanner/testssl.go
@@ -329,7 +329,7 @@ func GroupTestSSLOutputByIPPort(jsonData []byte) (map[string][]map[string]interf
 		if ip == "" || port == "" {
 			continue
 		}
-		key := ip + ":" + port
+		key := targetKey(ip, port)
 		grouped[key] = append(grouped[key], finding)
 	}
 


### PR DESCRIPTION
Adds support for ipv6.

Verified via the [TestTargetsPathIPv6](https://github.com/openshift/tls-scanner/pull/28/changes#diff-1e935cc4772e0ce3f14bdc4c1616774d7666507efe6502e0cbbd23fc62b55c26R147) test

Reference issue: https://github.com/openshift/tls-scanner/issues/26