### PR TITLE
Localhost port discovery

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -65,6 +65,7 @@ func NewClient() (*Client, error) {
 		dynamicClient:             dynamicClient,
 		processNameMap:            make(map[string]map[int]string),
 		listenInfoMap:             make(map[string]map[int]ListenInfo),
+		procListenAddrMap:         make(map[string]map[int]string),
 		processDiscoveryAttempted: make(map[string]bool),
 		namespace:                 namespace,
 		configClient:              configClient,

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -52,6 +52,11 @@ func (c *Client) DiscoverPortsFromProc(pod PodInfo) ([]int, error) {
 		return nil, fmt.Errorf("pod %s/%s has no containers", pod.Namespace, pod.Name)
 	}
 
+	// /proc/net/tcp is part of the network namespace, which is shared across
+	// ALL containers in a pod. Reading from Containers[0] gives complete
+	// visibility into every listening socket, including those owned by
+	// *secondary* containers (which have separate PID namespaces and are
+	// therefore invisible to lsof).
 	command := []string{"/bin/sh", "-c", "cat /proc/net/tcp /proc/net/tcp6 2>/dev/null"}
 	containerName := pod.Containers[0]
 
@@ -90,7 +95,29 @@ func (c *Client) DiscoverPortsFromProc(pod PodInfo) ([]int, error) {
 		return nil, fmt.Errorf("exec cat /proc/net/tcp in pod %s/%s failed: %w", pod.Namespace, pod.Name, err)
 	}
 
-	ports := ParseProcNetTCP(stdout.String())
+	addrMap := ParseProcNetTCPWithAddrs(stdout.String())
+
+	// Cache the decoded listen addresses so IsLocalhostOnly can use them as a
+	// fallback for ports owned by secondary containers (invisible to lsof).
+	if len(addrMap) > 0 {
+		c.processCacheMutex.Lock()
+		for _, ip := range pod.IPs {
+			if _, ok := c.procListenAddrMap[ip]; !ok {
+				c.procListenAddrMap[ip] = make(map[int]string)
+			}
+			for port, addr := range addrMap {
+				if _, exists := c.procListenAddrMap[ip][port]; !exists {
+					c.procListenAddrMap[ip][port] = addr
+				}
+			}
+		}
+		c.processCacheMutex.Unlock()
+	}
+
+	ports := make([]int, 0, len(addrMap))
+	for port := range addrMap {
+		ports = append(ports, port)
+	}
 	log.Printf("Discovered %d listening ports from /proc/net/tcp in pod %s/%s: %v", len(ports), pod.Namespace, pod.Name, ports)
 	return ports, nil
 }
@@ -172,6 +199,7 @@ func decodeProcNetAddr(hexAddr string) string {
 		return hexAddr
 	}
 }
+
 
 func UnionPorts(a, b []int) []int {
 	seen := make(map[int]struct{}, len(a)+len(b))

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
 )
@@ -200,7 +201,68 @@ func decodeProcNetAddr(hexAddr string) string {
 	}
 }
 
+// GetPlaintextProbePorts returns the set of port numbers that are referenced by
+// any liveness, readiness, or startup probe that does NOT use TLS (i.e. HTTP,
+// TCPSocket, or gRPC probes). Ports used by HTTPS probes are excluded so that
+// they continue to be scanned normally.
+//
+// Port references that use named ports (e.g. "healthz") are resolved against
+// each container's declared Ports list.
+func GetPlaintextProbePorts(pod *v1.Pod) map[int]bool {
+	result := make(map[int]bool)
 
+	for _, container := range pod.Spec.Containers {
+		namedPorts := buildNamedPortMap(container.Ports)
+
+		for _, probe := range []*v1.Probe{
+			container.LivenessProbe,
+			container.ReadinessProbe,
+			container.StartupProbe,
+		} {
+			if probe == nil {
+				continue
+			}
+			switch {
+			case probe.HTTPGet != nil:
+				if probe.HTTPGet.Scheme == v1.URISchemeHTTPS {
+					// HTTPS probe — TLS is explicitly in use; keep scanning this port.
+					continue
+				}
+				if port := resolveProbePort(probe.HTTPGet.Port, namedPorts); port > 0 {
+					result[port] = true
+				}
+			case probe.TCPSocket != nil:
+				if port := resolveProbePort(probe.TCPSocket.Port, namedPorts); port > 0 {
+					result[port] = true
+				}
+			case probe.GRPC != nil:
+				result[int(probe.GRPC.Port)] = true
+			}
+		}
+	}
+
+	return result
+}
+
+// buildNamedPortMap returns a name → port number map from a container's port list.
+func buildNamedPortMap(ports []v1.ContainerPort) map[string]int {
+	m := make(map[string]int, len(ports))
+	for _, p := range ports {
+		if p.Name != "" {
+			m[p.Name] = int(p.ContainerPort)
+		}
+	}
+	return m
+}
+
+// resolveProbePort resolves an IntOrString probe port to its integer value.
+// Named ports are looked up in namedPorts. Returns 0 if the name is not found.
+func resolveProbePort(port intstr.IntOrString, namedPorts map[string]int) int {
+	if port.Type == intstr.Int {
+		return int(port.IntVal)
+	}
+	return namedPorts[port.StrVal]
+}
 func UnionPorts(a, b []int) []int {
 	seen := make(map[int]struct{}, len(a)+len(b))
 	var result []int

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -263,6 +263,7 @@ func resolveProbePort(port intstr.IntOrString, namedPorts map[string]int) int {
 	}
 	return namedPorts[port.StrVal]
 }
+
 func UnionPorts(a, b []int) []int {
 	seen := make(map[int]struct{}, len(a)+len(b))
 	var result []int

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -224,7 +224,8 @@ func decodeProcNetAddr(hexAddr string) string {
 func GetPlaintextProbePorts(pod *v1.Pod) map[int]bool {
 	result := make(map[int]bool)
 
-	for _, container := range pod.Spec.Containers {
+	allContainers := append(pod.Spec.Containers, pod.Spec.InitContainers...)
+	for _, container := range allContainers {
 		namedPorts := buildNamedPortMap(container.Ports)
 
 		for _, probe := range []*v1.Probe{

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -3,8 +3,10 @@ package k8s
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"fmt"
 	"log"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -93,23 +95,24 @@ func (c *Client) DiscoverPortsFromProc(pod PodInfo) ([]int, error) {
 	return ports, nil
 }
 
-func ParseProcNetTCP(output string) []int {
-	seen := make(map[int]struct{})
-	var ports []int
+// ParseProcNetTCPWithAddrs parses /proc/net/tcp (and /proc/net/tcp6) output and
+// returns a map of port → decoded listen address for every socket in the LISTEN
+// state. When the same port appears multiple times the first entry wins.
+//
+// Addresses are returned as standard Go strings: "127.0.0.1", "0.0.0.0", "::1", "::", etc.
+func ParseProcNetTCPWithAddrs(output string) map[int]string {
+	result := make(map[int]string)
 
 	for _, line := range strings.Split(output, "\n") {
 		fields := strings.Fields(line)
 		if len(fields) < 4 {
 			continue
 		}
-
-		state := fields[3]
-		if state != procStateListen {
+		if fields[3] != procStateListen {
 			continue
 		}
 
-		localAddr := fields[1]
-		parts := strings.Split(localAddr, ":")
+		parts := strings.SplitN(fields[1], ":", 2)
 		if len(parts) != 2 {
 			continue
 		}
@@ -120,13 +123,54 @@ func ParseProcNetTCP(output string) []int {
 		}
 		port := int(port64)
 
-		if _, ok := seen[port]; !ok {
-			seen[port] = struct{}{}
-			ports = append(ports, port)
+		if _, exists := result[port]; !exists {
+			result[port] = decodeProcNetAddr(parts[0])
 		}
 	}
 
+	return result
+}
+
+// ParseProcNetTCP returns the list of listening port numbers.
+// It is a thin wrapper around ParseProcNetTCPWithAddrs that discards addresses.
+func ParseProcNetTCP(output string) []int {
+	addrMap := ParseProcNetTCPWithAddrs(output)
+	if len(addrMap) == 0 {
+		return nil
+	}
+	ports := make([]int, 0, len(addrMap))
+	for port := range addrMap {
+		ports = append(ports, port)
+	}
 	return ports
+}
+
+// decodeProcNetAddr converts a hex local-address field from /proc/net/tcp or
+// /proc/net/tcp6 into a human-readable IP string.
+//
+// IPv4 entries are 8 hex characters representing a little-endian uint32.
+// IPv6 entries are 32 hex characters representing four consecutive little-endian uint32s.
+func decodeProcNetAddr(hexAddr string) string {
+	b, err := hex.DecodeString(hexAddr)
+	if err != nil {
+		return hexAddr
+	}
+
+	switch len(b) {
+	case 4: // IPv4 — little-endian uint32
+		return fmt.Sprintf("%d.%d.%d.%d", b[3], b[2], b[1], b[0])
+	case 16: // IPv6 — four consecutive little-endian uint32s
+		decoded := make([]byte, 16)
+		for i := 0; i < 4; i++ {
+			decoded[i*4+0] = b[i*4+3]
+			decoded[i*4+1] = b[i*4+2]
+			decoded[i*4+2] = b[i*4+1]
+			decoded[i*4+3] = b[i*4+0]
+		}
+		return net.IP(decoded).String()
+	default:
+		return hexAddr
+	}
 }
 
 func UnionPorts(a, b []int) []int {

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -125,7 +125,13 @@ func (c *Client) DiscoverPortsFromProc(pod PodInfo) ([]int, error) {
 
 // ParseProcNetTCPWithAddrs parses /proc/net/tcp (and /proc/net/tcp6) output and
 // returns a map of port → decoded listen address for every socket in the LISTEN
-// state. When the same port appears multiple times the first entry wins.
+// state.
+//
+// When the same port appears on multiple rows (e.g. SO_REUSEPORT with mixed
+// bindings, or the same port in both /proc/net/tcp and /proc/net/tcp6), a
+// reachable address (0.0.0.0, ::, or any non-loopback) always takes precedence
+// over a loopback address. This prevents a false LOCALHOST_ONLY classification
+// when a port is bound to both 127.0.0.1 and 0.0.0.0.
 //
 // Addresses are returned as standard Go strings: "127.0.0.1", "0.0.0.0", "::1", "::", etc.
 func ParseProcNetTCPWithAddrs(output string) map[int]string {
@@ -150,9 +156,16 @@ func ParseProcNetTCPWithAddrs(output string) map[int]string {
 			continue
 		}
 		port := int(port64)
+		addr := decodeProcNetAddr(parts[0])
 
-		if _, exists := result[port]; !exists {
-			result[port] = decodeProcNetAddr(parts[0])
+		existing, seen := result[port]
+		if !seen {
+			result[port] = addr
+		} else if isLocalhostAddr(existing) && !isLocalhostAddr(addr) {
+			// A reachable binding overrides a previously recorded loopback one.
+			// The inverse is never allowed: once we know a port is reachable we
+			// do not let a later loopback row make it look localhost-only.
+			result[port] = addr
 		}
 	}
 

--- a/internal/k8s/discovery_test.go
+++ b/internal/k8s/discovery_test.go
@@ -160,7 +160,6 @@ func TestParseProcNetTCP(t *testing.T) {
 		})
 	}
 }
-
 func TestUnionPorts(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/k8s/discovery_test.go
+++ b/internal/k8s/discovery_test.go
@@ -288,6 +288,27 @@ func TestGetPlaintextProbePorts(t *testing.T) {
 			want: map[int]bool{},
 		},
 		{
+			name: "init container plaintext probe",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "main"},
+					},
+					InitContainers: []v1.Container{
+						{
+							Name: "init",
+							Ports: []v1.ContainerPort{
+								{Name: "healthz", ContainerPort: 9440, Protocol: v1.ProtocolTCP},
+							},
+							LivenessProbe: httpProbe(namedPort("healthz")),
+						},
+					},
+				},
+			},
+			want: map[int]bool{9440: true},
+		},
+		{
 			name: "no probes",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},

--- a/internal/k8s/discovery_test.go
+++ b/internal/k8s/discovery_test.go
@@ -6,6 +6,85 @@ import (
 	"testing"
 )
 
+func TestParseProcNetTCPWithAddrs(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  map[int]string
+	}{
+		{
+			name: "ipv4 localhost and wildcard",
+			input: `  sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode
+   0: 0100007F:2438 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 1 1 0000000000000000 100 0 0 10 0
+   1: 00000000:1F90 00000000:0000 0A 00000000:00000000 00:00000000 00000000     0        0 2 1 0000000000000000 100 0 0 10 0`,
+			want: map[int]string{9272: "127.0.0.1", 8080: "0.0.0.0"},
+		},
+		{
+			name: "ipv6 localhost",
+			input: `  sl  local_address                         remote_address                        st
+   0: 00000000000000000000000001000000:2710 00000000000000000000000000000000:0000 0A`,
+			want: map[int]string{10000: "::1"},
+		},
+		{
+			name: "ipv6 wildcard",
+			input: `  sl  local_address                         remote_address                        st
+   0: 00000000000000000000000000000000:01BB 00000000000000000000000000000000:0000 0A`,
+			want: map[int]string{443: "::"},
+		},
+		{
+			name: "duplicate port keeps first",
+			input: `  sl  local_address rem_address   st
+   0: 00000000:01BB 00000000:0000 0A
+   1: 0100007F:01BB 00000000:0000 0A`,
+			want: map[int]string{443: "0.0.0.0"},
+		},
+		{
+			name: "non-listen state skipped",
+			input: `  sl  local_address rem_address   st
+   0: 0100007F:C350 AC100164:01BB 01
+   1: 00000000:01BB 00000000:0000 0A`,
+			want: map[int]string{443: "0.0.0.0"},
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  map[int]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseProcNetTCPWithAddrs(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ParseProcNetTCPWithAddrs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDecodeProcNetAddr(t *testing.T) {
+	tests := []struct {
+		hex  string
+		want string
+	}{
+		{"0100007F", "127.0.0.1"},
+		{"00000000", "0.0.0.0"},
+		{"0101A8C0", "192.168.1.1"},
+		{"00000000000000000000000001000000", "::1"},
+		{"00000000000000000000000000000000", "::"},
+		{"invalid!", "invalid!"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.hex, func(t *testing.T) {
+			got := decodeProcNetAddr(tt.hex)
+			if got != tt.want {
+				t.Errorf("decodeProcNetAddr(%q) = %q, want %q", tt.hex, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseProcNetTCP(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/internal/k8s/discovery_test.go
+++ b/internal/k8s/discovery_test.go
@@ -36,11 +36,25 @@ func TestParseProcNetTCPWithAddrs(t *testing.T) {
 			want: map[int]string{443: "::"},
 		},
 		{
-			name: "duplicate port keeps first",
+			name: "wildcard before localhost — wildcard wins",
 			input: `  sl  local_address rem_address   st
    0: 00000000:01BB 00000000:0000 0A
    1: 0100007F:01BB 00000000:0000 0A`,
 			want: map[int]string{443: "0.0.0.0"},
+		},
+		{
+			name: "localhost before wildcard — wildcard still wins",
+			input: `  sl  local_address rem_address   st
+   0: 0100007F:01BB 00000000:0000 0A
+   1: 00000000:01BB 00000000:0000 0A`,
+			want: map[int]string{443: "0.0.0.0"},
+		},
+		{
+			name: "two localhost rows — stays localhost",
+			input: `  sl  local_address rem_address   st
+   0: 0100007F:1F90 00000000:0000 0A
+   1: 0100007F:1F90 00000000:0000 0A`,
+			want: map[int]string{8080: "127.0.0.1"},
 		},
 		{
 			name: "non-listen state skipped",

--- a/internal/k8s/discovery_test.go
+++ b/internal/k8s/discovery_test.go
@@ -4,6 +4,10 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 func TestParseProcNetTCPWithAddrs(t *testing.T) {
@@ -160,6 +164,137 @@ func TestParseProcNetTCP(t *testing.T) {
 		})
 	}
 }
+func intPort(n int) intstr.IntOrString     { return intstr.FromInt(n) }
+func namedPort(s string) intstr.IntOrString { return intstr.FromString(s) }
+
+func httpProbe(port intstr.IntOrString) *v1.Probe {
+	return &v1.Probe{ProbeHandler: v1.ProbeHandler{HTTPGet: &v1.HTTPGetAction{Port: port, Scheme: v1.URISchemeHTTP}}}
+}
+
+func httpsProbe(port intstr.IntOrString) *v1.Probe {
+	return &v1.Probe{ProbeHandler: v1.ProbeHandler{HTTPGet: &v1.HTTPGetAction{Port: port, Scheme: v1.URISchemeHTTPS}}}
+}
+
+func tcpProbe(port intstr.IntOrString) *v1.Probe {
+	return &v1.Probe{ProbeHandler: v1.ProbeHandler{TCPSocket: &v1.TCPSocketAction{Port: port}}}
+}
+
+func grpcProbe(port int32) *v1.Probe {
+	return &v1.Probe{ProbeHandler: v1.ProbeHandler{GRPC: &v1.GRPCAction{Port: port}}}
+}
+
+func TestGetPlaintextProbePorts(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want map[int]bool
+	}{
+		{
+			name: "http liveness probe by integer port",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "c", LivenessProbe: httpProbe(intPort(10301))},
+				}},
+			},
+			want: map[int]bool{10301: true},
+		},
+		{
+			name: "http liveness probe via named port",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{
+						Name: "c",
+						Ports: []v1.ContainerPort{
+							{Name: "healthz", ContainerPort: 10301, Protocol: v1.ProtocolTCP},
+						},
+						LivenessProbe: httpProbe(namedPort("healthz")),
+					},
+				}},
+			},
+			want: map[int]bool{10301: true},
+		},
+		{
+			name: "https liveness probe is NOT skipped",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "c", LivenessProbe: httpsProbe(intPort(8443))},
+				}},
+			},
+			want: map[int]bool{},
+		},
+		{
+			name: "tcp readiness probe",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "c", ReadinessProbe: tcpProbe(intPort(9090))},
+				}},
+			},
+			want: map[int]bool{9090: true},
+		},
+		{
+			name: "grpc startup probe",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "c", StartupProbe: grpcProbe(5000)},
+				}},
+			},
+			want: map[int]bool{5000: true},
+		},
+		{
+			name: "all three probe types across multiple containers",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{
+						Name:           "c1",
+						LivenessProbe:  httpProbe(intPort(8081)),
+						ReadinessProbe: httpsProbe(intPort(8443)), // HTTPS — must not be skipped
+					},
+					{
+						Name:         "c2",
+						StartupProbe: tcpProbe(intPort(9000)),
+					},
+				}},
+			},
+			want: map[int]bool{8081: true, 9000: true},
+		},
+		{
+			name: "named port not found returns zero — port excluded",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "c", LivenessProbe: httpProbe(namedPort("missing"))},
+				}},
+			},
+			want: map[int]bool{},
+		},
+		{
+			name: "no probes",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "c"},
+				}},
+			},
+			want: map[int]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPlaintextProbePorts(tt.pod)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetPlaintextProbePorts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUnionPorts(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/k8s/process.go
+++ b/internal/k8s/process.go
@@ -160,14 +160,36 @@ func (c *Client) IsLocalhostOnly(ip string, port int) (bool, string) {
 	c.processCacheMutex.Lock()
 	defer c.processCacheMutex.Unlock()
 
+	// Primary source: lsof data (covers ports visible from Containers[0]).
+	// When lsof has an entry for this port, treat it as authoritative and do
+	// not fall through to proc data — lsof provides richer process context and
+	// its bind address should be trusted over the kernel's /proc view.
 	if portMap, ok := c.listenInfoMap[ip]; ok {
 		if info, ok := portMap[port]; ok {
-			if info.ListenAddress == "127.0.0.1" || info.ListenAddress == "localhost" {
+			if isLocalhostAddr(info.ListenAddress) {
 				return true, info.ListenAddress
+			}
+			return false, ""
+		}
+	}
+
+	// Fallback: /proc/net/tcp data (covers all containers via shared network
+	// namespace, including ports owned by secondary containers that are
+	// invisible to lsof due to PID namespace isolation).
+	if addrMap, ok := c.procListenAddrMap[ip]; ok {
+		if addr, ok := addrMap[port]; ok {
+			if isLocalhostAddr(addr) {
+				return true, addr
 			}
 		}
 	}
+
 	return false, ""
+}
+
+// isLocalhostAddr reports whether addr is a loopback address.
+func isLocalhostAddr(addr string) bool {
+	return addr == "127.0.0.1" || addr == "::1" || addr == "localhost"
 }
 
 func (c *Client) GetListenInfo(ip string, port int) (ListenInfo, bool) {

--- a/internal/k8s/process_test.go
+++ b/internal/k8s/process_test.go
@@ -1,0 +1,127 @@
+package k8s
+
+import (
+	"testing"
+)
+
+// newTestClient returns a Client with all internal maps initialised, suitable
+// for unit tests that don't need a real Kubernetes API server.
+func newTestClient() *Client {
+	return &Client{
+		processNameMap:            make(map[string]map[int]string),
+		listenInfoMap:             make(map[string]map[int]ListenInfo),
+		procListenAddrMap:         make(map[string]map[int]string),
+		processDiscoveryAttempted: make(map[string]bool),
+	}
+}
+
+func TestIsLocalhostOnly_lsofData(t *testing.T) {
+	c := newTestClient()
+
+	// Populate listenInfoMap as lsof would.
+	c.listenInfoMap["10.0.0.1"] = map[int]ListenInfo{
+		9259: {Port: 9259, ListenAddress: "127.0.0.1", ProcessName: "myprocess"},
+		9258: {Port: 9258, ListenAddress: "*", ProcessName: "myprocess"},
+	}
+
+	tests := []struct {
+		port      int
+		wantIs    bool
+		wantAddr  string
+	}{
+		{9259, true, "127.0.0.1"},  // localhost in lsof data
+		{9258, false, ""},          // wildcard in lsof data
+		{9999, false, ""},          // unknown port
+	}
+
+	for _, tt := range tests {
+		gotIs, gotAddr := c.IsLocalhostOnly("10.0.0.1", tt.port)
+		if gotIs != tt.wantIs || gotAddr != tt.wantAddr {
+			t.Errorf("IsLocalhostOnly(port=%d) = (%v, %q), want (%v, %q)",
+				tt.port, gotIs, gotAddr, tt.wantIs, tt.wantAddr)
+		}
+	}
+}
+
+func TestIsLocalhostOnly_procFallback(t *testing.T) {
+	c := newTestClient()
+
+	// No lsof data at all (secondary container scenario).
+	// Proc data covers all sockets via shared network namespace.
+	c.procListenAddrMap["10.0.0.1"] = map[int]string{
+		9260: "127.0.0.1", // secondary container's localhost port
+		9261: "0.0.0.0",   // secondary container's wildcard port
+	}
+
+	tests := []struct {
+		port     int
+		wantIs   bool
+		wantAddr string
+	}{
+		{9260, true, "127.0.0.1"},  // localhost via proc fallback
+		{9261, false, ""},          // wildcard — not localhost
+		{9999, false, ""},          // unknown
+	}
+
+	for _, tt := range tests {
+		gotIs, gotAddr := c.IsLocalhostOnly("10.0.0.1", tt.port)
+		if gotIs != tt.wantIs || gotAddr != tt.wantAddr {
+			t.Errorf("IsLocalhostOnly(port=%d) = (%v, %q), want (%v, %q)",
+				tt.port, gotIs, gotAddr, tt.wantIs, tt.wantAddr)
+		}
+	}
+}
+
+func TestIsLocalhostOnly_lsofTakesPrecedence(t *testing.T) {
+	c := newTestClient()
+
+	// lsof says port 9000 is wildcard; proc says it is localhost.
+	// lsof should win (it has richer context from the process perspective).
+	c.listenInfoMap["10.0.0.1"] = map[int]ListenInfo{
+		9000: {Port: 9000, ListenAddress: "*", ProcessName: "svc"},
+	}
+	c.procListenAddrMap["10.0.0.1"] = map[int]string{
+		9000: "127.0.0.1",
+	}
+
+	gotIs, _ := c.IsLocalhostOnly("10.0.0.1", 9000)
+	if gotIs {
+		t.Error("expected IsLocalhostOnly=false when lsof shows wildcard, even if proc shows localhost")
+	}
+}
+
+func TestIsLocalhostOnly_ipv6Localhost(t *testing.T) {
+	c := newTestClient()
+
+	c.procListenAddrMap["10.0.0.2"] = map[int]string{
+		8080: "::1",
+	}
+
+	gotIs, gotAddr := c.IsLocalhostOnly("10.0.0.2", 8080)
+	if !gotIs || gotAddr != "::1" {
+		t.Errorf("IsLocalhostOnly() = (%v, %q), want (true, %q)", gotIs, gotAddr, "::1")
+	}
+}
+
+func TestIsLocalhostAddr(t *testing.T) {
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"localhost", true},
+		{"0.0.0.0", false},
+		{"::", false},
+		{"*", false},
+		{"10.0.0.1", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		got := isLocalhostAddr(tt.addr)
+		if got != tt.want {
+			t.Errorf("isLocalhostAddr(%q) = %v, want %v", tt.addr, got, tt.want)
+		}
+	}
+}

--- a/internal/k8s/types.go
+++ b/internal/k8s/types.go
@@ -66,6 +66,11 @@ type Client struct {
 	dynamicClient             dynamic.Interface
 	processNameMap            map[string]map[int]string
 	listenInfoMap             map[string]map[int]ListenInfo
+	// procListenAddrMap holds the decoded listen address for every port seen in
+	// /proc/net/tcp(6). It covers all containers in a pod (shared network
+	// namespace) and is used by IsLocalhostOnly as a fallback when lsof data is
+	// unavailable for a port (e.g. ports owned by secondary containers).
+	procListenAddrMap         map[string]map[int]string
 	processDiscoveryAttempted map[string]bool
 	processCacheMutex         sync.Mutex
 	namespace                 string

--- a/internal/output/junit.go
+++ b/internal/output/junit.go
@@ -71,7 +71,8 @@ func WriteJUnitOutput(scanResults scanner.ScanResults, filename string, pqcCheck
 
 			if pqcCheck && portResult.Status != scanner.StatusNoPorts &&
 				portResult.Status != scanner.StatusLocalhostOnly &&
-				portResult.Status != scanner.StatusNoTLS {
+				portResult.Status != scanner.StatusNoTLS &&
+				portResult.Status != scanner.StatusProbePort {
 				if !portResult.TLS13Supported {
 					failures = append(failures, "PQC: TLS 1.3 not supported.")
 				}

--- a/internal/scanner/pqc.go
+++ b/internal/scanner/pqc.go
@@ -5,7 +5,7 @@ import "log"
 type PortFilter func(status ScanStatus) bool
 
 var SkipUnscannable PortFilter = func(status ScanStatus) bool {
-	return status == StatusNoPorts || status == StatusLocalhostOnly || status == StatusNoTLS
+	return status == StatusNoPorts || status == StatusLocalhostOnly || status == StatusNoTLS || status == StatusProbePort
 }
 
 var (

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -75,79 +75,110 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 					component, _ = client.GetOpenshiftComponentFromImage(pod.Image)
 				}
 
-				specPorts, _ := k8s.DiscoverPortsFromPodSpec(pod.Pod)
-				var procPorts []int
-				if client != nil {
-					var err error
-					procPorts, err = client.DiscoverPortsFromProc(pod)
-					if err != nil {
-						log.Printf("Warning: /proc port discovery failed for %s/%s: %v", pod.Namespace, pod.Name, err)
+			specPorts, _ := k8s.DiscoverPortsFromPodSpec(pod.Pod)
+			var procPorts []int
+			if client != nil {
+				var err error
+				procPorts, err = client.DiscoverPortsFromProc(pod)
+				if err != nil {
+					log.Printf("Warning: /proc port discovery failed for %s/%s: %v", pod.Namespace, pod.Name, err)
+				}
+			}
+
+			var processMap map[string]map[int]string
+			if client != nil && len(pod.Containers) > 0 {
+				processMap = client.GetAndCachePodProcesses(pod)
+			}
+
+			if pod.Pod.Spec.HostNetwork && processMap != nil && len(procPorts) > 0 {
+				procPorts = filterByProcessPorts(processMap, procPorts)
+			}
+
+			openPorts := k8s.UnionPorts(specPorts, procPorts)
+
+			// Identify plaintext probe ports up front so we can skip them below.
+			probePorts := k8s.GetPlaintextProbePorts(pod.Pod)
+
+			log.Printf("DISCOVERY %d: %s/%s hostNet=%v spec=%v proc=%v union=%v probePorts=%v (%d ports)",
+				workerID, pod.Namespace, pod.Name, pod.Pod.Spec.HostNetwork, specPorts, procPorts, openPorts, probePorts, len(openPorts))
+
+			for _, ip := range pod.IPs {
+				if len(openPorts) == 0 {
+					progress.PortSkipped()
+					mu.Lock()
+					localhostResults = append(localhostResults, portScanResult{
+						ip:        ip,
+						pod:       pod,
+						component: component,
+						result: PortResult{
+							Port:   0,
+							Status: StatusNoPorts,
+							Reason: "No listening TCP ports found (spec or /proc/net/tcp)",
+						},
+					})
+					mu.Unlock()
+					continue
+				}
+
+				for _, port := range openPorts {
+					if client != nil {
+						if isLocalhost, listenAddr := client.IsLocalhostOnly(ip, port); isLocalhost {
+							log.Printf("Port %d on %s is bound to localhost only (%s), skipping", port, ip, listenAddr)
+							pr := PortResult{
+								Port:          port,
+								Protocol:      "tcp",
+								State:         "localhost",
+								Status:        StatusLocalhostOnly,
+								Reason:        fmt.Sprintf("Bound to %s, not accessible from pod IP", listenAddr),
+								ListenAddress: listenAddr,
+							}
+							if processName, ok := client.GetProcessName(ip, port); ok {
+								pr.ProcessName = processName
+								pr.ContainerName = strings.Join(pod.Containers, ",")
+							}
+							progress.PortSkipped()
+							mu.Lock()
+							localhostResults = append(localhostResults, portScanResult{
+								ip: ip, pod: pod, component: component, result: pr,
+							})
+							mu.Unlock()
+							continue
+						}
 					}
-				}
 
-				var processMap map[string]map[int]string
-				if client != nil && len(pod.Containers) > 0 {
-					processMap = client.GetAndCachePodProcesses(pod)
-				}
-
-				if pod.Pod.Spec.HostNetwork && processMap != nil && len(procPorts) > 0 {
-					procPorts = filterByProcessPorts(processMap, procPorts)
-				}
-
-				openPorts := k8s.UnionPorts(specPorts, procPorts)
-
-				log.Printf("DISCOVERY %d: %s/%s hostNet=%v spec=%v proc=%v union=%v (%d ports)",
-					workerID, pod.Namespace, pod.Name, pod.Pod.Spec.HostNetwork, specPorts, procPorts, openPorts, len(openPorts))
-
-				for _, ip := range pod.IPs {
-					if len(openPorts) == 0 {
+					if probePorts[port] {
+						log.Printf("Port %d on %s is a plaintext health probe endpoint, skipping TLS scan", port, ip)
+						pr := PortResult{
+							Port:     port,
+							Protocol: "tcp",
+							State:    "open",
+							Status:   StatusProbePort,
+							Reason:   "Port is used as a plaintext health probe endpoint (HTTP/TCP/gRPC), TLS not expected",
+						}
+						if client != nil {
+							if processName, ok := client.GetProcessName(ip, port); ok {
+								pr.ProcessName = processName
+								pr.ContainerName = strings.Join(pod.Containers, ",")
+							}
+							if info, ok := client.GetListenInfo(ip, port); ok {
+								pr.ListenAddress = info.ListenAddress
+							}
+						}
 						progress.PortSkipped()
 						mu.Lock()
 						localhostResults = append(localhostResults, portScanResult{
-							ip:        ip,
-							pod:       pod,
-							component: component,
-							result: PortResult{
-								Port:   0,
-								Status: StatusNoPorts,
-								Reason: "No listening TCP ports found (spec or /proc/net/tcp)",
-							},
+							ip: ip, pod: pod, component: component, result: pr,
 						})
 						mu.Unlock()
 						continue
 					}
 
-					for _, port := range openPorts {
-						if client != nil {
-							if isLocalhost, listenAddr := client.IsLocalhostOnly(ip, port); isLocalhost {
-								log.Printf("Port %d on %s is bound to localhost only (%s), skipping", port, ip, listenAddr)
-								pr := PortResult{
-									Port:          port,
-									Protocol:      "tcp",
-									State:         "localhost",
-									Status:        StatusLocalhostOnly,
-									Reason:        fmt.Sprintf("Bound to %s, not accessible from pod IP", listenAddr),
-									ListenAddress: listenAddr,
-								}
-								if processName, ok := client.GetProcessName(ip, port); ok {
-									pr.ProcessName = processName
-									pr.ContainerName = strings.Join(pod.Containers, ",")
-								}
-								progress.PortSkipped()
-								mu.Lock()
-								localhostResults = append(localhostResults, portScanResult{
-									ip: ip, pod: pod, component: component, result: pr,
-								})
-								mu.Unlock()
-								continue
-							}
-						}
-						progress.PortQueued()
-						mu.Lock()
-						scanJobs = append(scanJobs, ScanJob{IP: ip, Port: port, Pod: pod, Component: component})
-						mu.Unlock()
-					}
+					progress.PortQueued()
+					mu.Lock()
+					scanJobs = append(scanJobs, ScanJob{IP: ip, Port: port, Pod: pod, Component: component})
+					mu.Unlock()
 				}
+			}
 			}
 		}(w + 1)
 	}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -75,32 +75,45 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 					component, _ = client.GetOpenshiftComponentFromImage(pod.Image)
 				}
 
-				specPorts, _ := k8s.DiscoverPortsFromPodSpec(pod.Pod)
-				var procPorts []int
-				if client != nil {
-					var err error
-					procPorts, err = client.DiscoverPortsFromProc(pod)
-					if err != nil {
-						log.Printf("Warning: /proc port discovery failed for %s/%s: %v", pod.Namespace, pod.Name, err)
-					}
+			specPorts, _ := k8s.DiscoverPortsFromPodSpec(pod.Pod)
+			var procPorts []int
+			procAvailable := false
+			if client != nil {
+				var err error
+				procPorts, err = client.DiscoverPortsFromProc(pod)
+				if err != nil {
+					log.Printf("Warning: /proc port discovery failed for %s/%s: %v", pod.Namespace, pod.Name, err)
+				} else {
+					procAvailable = true
 				}
+			}
 
-				var processMap map[string]map[int]string
-				if client != nil && len(pod.Containers) > 0 {
-					processMap = client.GetAndCachePodProcesses(pod)
-				}
+			var processMap map[string]map[int]string
+			if client != nil && len(pod.Containers) > 0 {
+				processMap = client.GetAndCachePodProcesses(pod)
+			}
 
-				if pod.Pod.Spec.HostNetwork && processMap != nil && len(procPorts) > 0 {
-					procPorts = filterByProcessPorts(processMap, procPorts)
-				}
+			if pod.Pod.Spec.HostNetwork && processMap != nil && len(procPorts) > 0 {
+				procPorts = filterByProcessPorts(processMap, procPorts)
+			}
 
-				openPorts := k8s.UnionPorts(specPorts, procPorts)
+			// When /proc data is available use it as the ground truth — only
+			// ports with an active listener are included. Fall back to
+			// spec-declared ports only when proc discovery is unavailable or
+			// failed, to avoid false positives from containerPorts that are
+			// declared but never actually bound.
+			var openPorts []int
+			if procAvailable {
+				openPorts = procPorts
+			} else {
+				openPorts = specPorts
+			}
 
-				// Identify plaintext probe ports up front so we can skip them below.
-				probePorts := k8s.GetPlaintextProbePorts(pod.Pod)
+			// Identify plaintext probe ports up front so we can skip them below.
+			probePorts := k8s.GetPlaintextProbePorts(pod.Pod)
 
-				log.Printf("DISCOVERY %d: %s/%s hostNet=%v spec=%v proc=%v union=%v probePorts=%v (%d ports)",
-					workerID, pod.Namespace, pod.Name, pod.Pod.Spec.HostNetwork, specPorts, procPorts, openPorts, probePorts, len(openPorts))
+			log.Printf("DISCOVERY %d: %s/%s hostNet=%v spec=%v proc=%v open=%v probePorts=%v (%d ports)",
+				workerID, pod.Namespace, pod.Name, pod.Pod.Spec.HostNetwork, specPorts, procPorts, openPorts, probePorts, len(openPorts))
 
 				for _, ip := range pod.IPs {
 					if len(openPorts) == 0 {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -75,66 +75,94 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 					component, _ = client.GetOpenshiftComponentFromImage(pod.Image)
 				}
 
-			specPorts, _ := k8s.DiscoverPortsFromPodSpec(pod.Pod)
-			var procPorts []int
-			if client != nil {
-				var err error
-				procPorts, err = client.DiscoverPortsFromProc(pod)
-				if err != nil {
-					log.Printf("Warning: /proc port discovery failed for %s/%s: %v", pod.Namespace, pod.Name, err)
-				}
-			}
-
-			var processMap map[string]map[int]string
-			if client != nil && len(pod.Containers) > 0 {
-				processMap = client.GetAndCachePodProcesses(pod)
-			}
-
-			if pod.Pod.Spec.HostNetwork && processMap != nil && len(procPorts) > 0 {
-				procPorts = filterByProcessPorts(processMap, procPorts)
-			}
-
-			openPorts := k8s.UnionPorts(specPorts, procPorts)
-
-			// Identify plaintext probe ports up front so we can skip them below.
-			probePorts := k8s.GetPlaintextProbePorts(pod.Pod)
-
-			log.Printf("DISCOVERY %d: %s/%s hostNet=%v spec=%v proc=%v union=%v probePorts=%v (%d ports)",
-				workerID, pod.Namespace, pod.Name, pod.Pod.Spec.HostNetwork, specPorts, procPorts, openPorts, probePorts, len(openPorts))
-
-			for _, ip := range pod.IPs {
-				if len(openPorts) == 0 {
-					progress.PortSkipped()
-					mu.Lock()
-					localhostResults = append(localhostResults, portScanResult{
-						ip:        ip,
-						pod:       pod,
-						component: component,
-						result: PortResult{
-							Port:   0,
-							Status: StatusNoPorts,
-							Reason: "No listening TCP ports found (spec or /proc/net/tcp)",
-						},
-					})
-					mu.Unlock()
-					continue
+				specPorts, _ := k8s.DiscoverPortsFromPodSpec(pod.Pod)
+				var procPorts []int
+				if client != nil {
+					var err error
+					procPorts, err = client.DiscoverPortsFromProc(pod)
+					if err != nil {
+						log.Printf("Warning: /proc port discovery failed for %s/%s: %v", pod.Namespace, pod.Name, err)
+					}
 				}
 
-				for _, port := range openPorts {
-					if client != nil {
-						if isLocalhost, listenAddr := client.IsLocalhostOnly(ip, port); isLocalhost {
-							log.Printf("Port %d on %s is bound to localhost only (%s), skipping", port, ip, listenAddr)
-							pr := PortResult{
-								Port:          port,
-								Protocol:      "tcp",
-								State:         "localhost",
-								Status:        StatusLocalhostOnly,
-								Reason:        fmt.Sprintf("Bound to %s, not accessible from pod IP", listenAddr),
-								ListenAddress: listenAddr,
+				var processMap map[string]map[int]string
+				if client != nil && len(pod.Containers) > 0 {
+					processMap = client.GetAndCachePodProcesses(pod)
+				}
+
+				if pod.Pod.Spec.HostNetwork && processMap != nil && len(procPorts) > 0 {
+					procPorts = filterByProcessPorts(processMap, procPorts)
+				}
+
+				openPorts := k8s.UnionPorts(specPorts, procPorts)
+
+				// Identify plaintext probe ports up front so we can skip them below.
+				probePorts := k8s.GetPlaintextProbePorts(pod.Pod)
+
+				log.Printf("DISCOVERY %d: %s/%s hostNet=%v spec=%v proc=%v union=%v probePorts=%v (%d ports)",
+					workerID, pod.Namespace, pod.Name, pod.Pod.Spec.HostNetwork, specPorts, procPorts, openPorts, probePorts, len(openPorts))
+
+				for _, ip := range pod.IPs {
+					if len(openPorts) == 0 {
+						progress.PortSkipped()
+						mu.Lock()
+						localhostResults = append(localhostResults, portScanResult{
+							ip:        ip,
+							pod:       pod,
+							component: component,
+							result: PortResult{
+								Port:   0,
+								Status: StatusNoPorts,
+								Reason: "No listening TCP ports found (spec or /proc/net/tcp)",
+							},
+						})
+						mu.Unlock()
+						continue
+					}
+
+					for _, port := range openPorts {
+						if client != nil {
+							if isLocalhost, listenAddr := client.IsLocalhostOnly(ip, port); isLocalhost {
+								log.Printf("Port %d on %s is bound to localhost only (%s), skipping", port, ip, listenAddr)
+								pr := PortResult{
+									Port:          port,
+									Protocol:      "tcp",
+									State:         "localhost",
+									Status:        StatusLocalhostOnly,
+									Reason:        fmt.Sprintf("Bound to %s, not accessible from pod IP", listenAddr),
+									ListenAddress: listenAddr,
+								}
+								if processName, ok := client.GetProcessName(ip, port); ok {
+									pr.ProcessName = processName
+									pr.ContainerName = strings.Join(pod.Containers, ",")
+								}
+								progress.PortSkipped()
+								mu.Lock()
+								localhostResults = append(localhostResults, portScanResult{
+									ip: ip, pod: pod, component: component, result: pr,
+								})
+								mu.Unlock()
+								continue
 							}
-							if processName, ok := client.GetProcessName(ip, port); ok {
-								pr.ProcessName = processName
-								pr.ContainerName = strings.Join(pod.Containers, ",")
+						}
+
+						if probePorts[port] {
+							log.Printf("Port %d on %s is a plaintext health probe endpoint, skipping TLS scan", port, ip)
+							pr := PortResult{
+								Port:     port,
+								Protocol: "tcp",
+								State:    "open",
+								Status:   StatusProbePort,
+								Reason:   "Port is used as a plaintext health probe endpoint (HTTP/TCP/gRPC), TLS not expected",
+							}
+							if client != nil {
+								if processName, ok := client.GetProcessName(ip, port); ok {
+									pr.ProcessName = processName
+									pr.ContainerName = strings.Join(pod.Containers, ",")
+								}
+								if info, ok := client.GetListenInfo(ip, port); ok {
+									pr.ListenAddress = info.ListenAddress
+								}
 							}
 							progress.PortSkipped()
 							mu.Lock()
@@ -144,41 +172,13 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 							mu.Unlock()
 							continue
 						}
-					}
 
-					if probePorts[port] {
-						log.Printf("Port %d on %s is a plaintext health probe endpoint, skipping TLS scan", port, ip)
-						pr := PortResult{
-							Port:     port,
-							Protocol: "tcp",
-							State:    "open",
-							Status:   StatusProbePort,
-							Reason:   "Port is used as a plaintext health probe endpoint (HTTP/TCP/gRPC), TLS not expected",
-						}
-						if client != nil {
-							if processName, ok := client.GetProcessName(ip, port); ok {
-								pr.ProcessName = processName
-								pr.ContainerName = strings.Join(pod.Containers, ",")
-							}
-							if info, ok := client.GetListenInfo(ip, port); ok {
-								pr.ListenAddress = info.ListenAddress
-							}
-						}
-						progress.PortSkipped()
+						progress.PortQueued()
 						mu.Lock()
-						localhostResults = append(localhostResults, portScanResult{
-							ip: ip, pod: pod, component: component, result: pr,
-						})
+						scanJobs = append(scanJobs, ScanJob{IP: ip, Port: port, Pod: pod, Component: component})
 						mu.Unlock()
-						continue
 					}
-
-					progress.PortQueued()
-					mu.Lock()
-					scanJobs = append(scanJobs, ScanJob{IP: ip, Port: port, Pod: pod, Component: component})
-					mu.Unlock()
 				}
-			}
 			}
 		}(w + 1)
 	}

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -96,6 +96,10 @@ const (
 	StatusNoTLS         ScanStatus = "NO_TLS"
 	StatusLocalhostOnly ScanStatus = "LOCALHOST_ONLY"
 	StatusNoPorts       ScanStatus = "NO_PORTS"
+	// StatusProbePort indicates the port is used exclusively as a health probe
+	// endpoint (liveness, readiness, or startup) with a plaintext protocol
+	// (HTTP, TCP, or gRPC). TLS is not expected on such ports.
+	StatusProbePort ScanStatus = "PROBE_PORT"
 )
 
 type PortResult struct {


### PR DESCRIPTION
Fix false-positive NO_TLS results for localhost and health-probe ports
Closes #33, closes #34

The scanner was producing a number of spurious NO_TLS results from two (independent) root causes:

## Multi-container localhost ports (#33)
lsof is executed only in Containers[0]. Because containers share a network namespace but have separate PID namespaces, lsof cannot see sockets owned by secondary containers. Those ports appeared in /proc/net/tcp (shared), had no listenInfoMap entry, and so IsLocalhostOnly returned false — sending them to testssl.sh where they were reported as NO_TLS.

## Health probe ports (#34)
Liveness, readiness, and startup probes that use plaintext HTTP, TCPSocket, or gRPC listen on ports that are intentionally not TLS-protected. The scanner had no awareness of these probe endpoints and scanned them unconditionally, producing false positives for the vast majority of OpenShift components.

# Solution
## Fix 1 — /proc/net/tcp-based localhost detection (Option B from #33)
/proc/net/tcp is a view of the pod's shared network namespace and therefore already shows every socket across all containers — including those in secondary containers invisible to lsof. Previously only port numbers were extracted from it; the local address column was discarded.

ParseProcNetTCPWithAddrs now returns map[int]string (port -> decoded listen address). decodeProcNetAddr converts the little-endian hex fields used by /proc/net/tcp and /proc/net/tcp6 into standard IP strings ("127.0.0.1", "::1", "0.0.0.0", etc.).

DiscoverPortsFromProc caches these decoded addresses into a new procListenAddrMap on Client.

IsLocalhostOnly falls back to procListenAddrMap when lsof has no entry for a port. This is the case that will tell us if the endpoint is a secondary container listening on localhost. *When lsof does have an entry it remains authoritative.*

## Fix 2 — Plaintext health probe port detection (#34)
The Kubernetes pod spec has structured fields for probes (livenessProbe, readinessProbe, startupProbe) with an explicit scheme field on HTTP probes (HTTP or HTTPS). This gives unambiguous, API-sourced signal about whether TLS is expected on a port!

GetPlaintextProbePorts reads all three probe fields across all containers and returns the set of ports whose probes are plaintext (HTTP, TCPSocket, or gRPC). Named port references (e.g. "healthz") are resolved against each container's Ports list.

Ports probed via HTTPS are explicitly excluded and continue to be TLS-scanned.

In the scanner discovery loop, plaintext probe ports are recorded with a new PROBE_PORT status and skipped by testssl.sh, the same way LOCALHOST_ONLY ports are handled.

## New Status Values
- `PROBE_PORT`: Indicates that this endpoint belongs to a probe. These are handled like LOCALHOST_ONLY endpoints and are skipped by testssl.sh scan.