### PR TITLE
Add cipher per proto flag

### DIFF
--- a/cmd/tls-scanner/main.go
+++ b/cmd/tls-scanner/main.go
@@ -66,6 +66,7 @@ func run(args []string) (exitCode int) {
 	limitIPs := fs.Int("limit-ips", 0, "Limit the number of IPs to scan for testing purposes (0 = no limit)")
 	logFile := fs.String("log-file", "", "Redirect all log output to the specified file")
 	pqcCheck := fs.Bool("pqc-check", false, "Quick check for TLS 1.3 and ML-KEM (post-quantum) support only")
+	cipherPerProto := fs.Bool("E", false, "Check ciphers per protocol (like testssl.sh -E / --cipher-per-proto)")
 	timingFile := fs.String("timing-file", "", "Output timing report to specified file in artifact-dir")
 	showVersion := fs.Bool("version", false, "Print version and exit")
 
@@ -145,7 +146,7 @@ func run(args []string) (exitCode int) {
 			return 1
 		}
 
-		scanResults := scanner.Scan(jobs, *concurrentScans, nil, nil)
+		scanResults := scanner.Scan(jobs, *concurrentScans, nil, nil, *cipherPerProto)
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
@@ -202,7 +203,7 @@ func run(args []string) (exitCode int) {
 	}
 
 	if len(pods) > 0 {
-		scanResults := scanner.PerformClusterScan(pods, *concurrentScans, client)
+		scanResults := scanner.PerformClusterScan(pods, *concurrentScans, client, *cipherPerProto)
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
@@ -225,7 +226,7 @@ func run(args []string) (exitCode int) {
 	}
 
 	jobs := []scanner.ScanJob{{IP: normalizeHost(*host), Port: portNum}}
-	scanResults := scanner.Scan(jobs, *concurrentScans, client, nil)
+	scanResults := scanner.Scan(jobs, *concurrentScans, client, nil, *cipherPerProto)
 	finalScanResults = &scanResults
 
 	if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {

--- a/cmd/tls-scanner/main_test.go
+++ b/cmd/tls-scanner/main_test.go
@@ -12,10 +12,12 @@ import (
 const mockTestSSLScript = `#!/bin/bash
 JSONFILE=""
 TARGETS_FILE=""
+CIPHER_PER_PROTO=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --jsonfile) JSONFILE="$2"; shift 2;;
         --file) TARGETS_FILE="$2"; shift 2;;
+        -E) CIPHER_PER_PROTO=true; shift;;
         *) shift;;
     esac
 done
@@ -36,6 +38,12 @@ while IFS= read -r target; do
     printf '{"id":"FS","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"}' "$ip" "$ip" "$port"
     if [ -z "${MOCK_NO_MLKEM:-}" ]; then
         printf ',{"id":"FS_KEMs","ip":"%s/%s","port":"%s","severity":"OK","finding":"x25519mlkem768"}' "$ip" "$ip" "$port"
+    fi
+    if [ "$CIPHER_PER_PROTO" = true ]; then
+        printf ',{"id":"cipher-tls1_2-x0033","ip":"%s/%s","port":"%s","severity":"OK","finding":"TLS_RSA_WITH_AES_128_CBC_SHA RSA AES 128"}' "$ip" "$ip" "$port"
+        printf ',{"id":"cipher-tls1_2-xc02f","ip":"%s/%s","port":"%s","severity":"OK","finding":"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ECDH AESGCM 128"}' "$ip" "$ip" "$port"
+        printf ',{"id":"cipher-tls1_3-x1301","ip":"%s/%s","port":"%s","severity":"OK","finding":"TLS_AES_128_GCM_SHA256 ECDH AESGCM 128"}' "$ip" "$ip" "$port"
+        printf ',{"id":"cipher-tls1_3-x1302","ip":"%s/%s","port":"%s","severity":"OK","finding":"TLS_AES_256_GCM_SHA384 ECDH AESGCM 256"}' "$ip" "$ip" "$port"
     fi
 done < "$TARGETS_FILE"
 printf ']'
@@ -251,6 +259,73 @@ func TestPQCComplianceFailure(t *testing.T) {
 	}
 	if pr.MLKEMSupported {
 		t.Error("expected MLKEMSupported=false (mock omits MLKEM)")
+	}
+}
+
+func TestCipherPerProtoFlag(t *testing.T) {
+	installMockTestSSL(t)
+	outDir := t.TempDir()
+
+	code := run([]string{
+		"-E",
+		"--targets", "10.0.0.1:443",
+		"--json-file", "results.json",
+		"--artifact-dir", outDir,
+		"-j", "1",
+	})
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d", code)
+	}
+
+	results := readJSONResults(t, outDir, "results.json")
+	if results.ScannedIPs != 1 {
+		t.Fatalf("expected 1 scanned IP, got %d", results.ScannedIPs)
+	}
+
+	pr := results.IPResults[0].PortResults[0]
+	if pr.Status != scanner.StatusOK {
+		t.Errorf("expected status OK, got %s", pr.Status)
+	}
+
+	if len(pr.TlsCiphersPerProto) == 0 {
+		t.Fatal("expected TlsCiphersPerProto to be populated")
+	}
+
+	tls12Ciphers, ok := pr.TlsCiphersPerProto["TLSv1.2"]
+	if !ok {
+		t.Fatal("expected TLSv1.2 ciphers in per-proto results")
+	}
+	if len(tls12Ciphers) != 2 {
+		t.Errorf("expected 2 TLSv1.2 ciphers, got %d", len(tls12Ciphers))
+	}
+
+	tls13Ciphers, ok := pr.TlsCiphersPerProto["TLSv1.3"]
+	if !ok {
+		t.Fatal("expected TLSv1.3 ciphers in per-proto results")
+	}
+	if len(tls13Ciphers) != 2 {
+		t.Errorf("expected 2 TLSv1.3 ciphers, got %d", len(tls13Ciphers))
+	}
+}
+
+func TestCipherPerProtoNotPresentByDefault(t *testing.T) {
+	installMockTestSSL(t)
+	outDir := t.TempDir()
+
+	code := run([]string{
+		"--targets", "10.0.0.1:443",
+		"--json-file", "results.json",
+		"--artifact-dir", outDir,
+		"-j", "1",
+	})
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d", code)
+	}
+
+	results := readJSONResults(t, outDir, "results.json")
+	pr := results.IPResults[0].PortResults[0]
+	if len(pr.TlsCiphersPerProto) != 0 {
+		t.Errorf("expected TlsCiphersPerProto to be empty without -E flag, got %d protocols", len(pr.TlsCiphersPerProto))
 	}
 }
 

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -13,7 +13,7 @@ import (
 
 var csvColumns = []string{
 	"IP", "Port", "Protocol", "Service", "Pod Name", "Namespace", "Component Name", "Component Maintainer",
-	"Process", "TLS Ciphers", "TLS Version", "TLS Supported Groups", "Status", "Reason", "Listen Address",
+	"Process", "TLS Ciphers", "TLS Version", "TLS Supported Groups", "TLS Ciphers Per Proto", "Status", "Reason", "Listen Address",
 	"TLS 1.3 Supported", "ML-KEM Supported", "ML-KEM KEMs", "All KEMs",
 	"TLS 1.3 Offered", "TLS 1.2 Only", "PQC Capable", "Readiness Notes",
 	"Ingress Configured Profile", "Ingress Configured MinVersion", "Ingress MinVersion Compliance", "Ingress Configured Ciphers", "Ingress Cipher Compliance",
@@ -130,6 +130,7 @@ func WriteCSVOutput(results scanner.ScanResults, filename string) error {
 				"TLS Ciphers":                   joinOrNA(portResult.TlsCiphers),
 				"TLS Version":                   joinOrNA(portResult.TlsVersions),
 				"TLS Supported Groups":          supportedGroups,
+				"TLS Ciphers Per Proto":         formatCiphersPerProto(portResult.TlsCiphersPerProto),
 				"Status":                        statusStr,
 				"Reason":                        stringOrNA(portResult.Reason),
 				"Listen Address":                stringOrNA(portResult.ListenAddress),
@@ -272,6 +273,29 @@ func boolToYesNo(b bool) string {
 		return "Yes"
 	}
 	return "No"
+}
+
+func formatCiphersPerProto(cpp map[string][]scanner.CipherDetail) string {
+	if len(cpp) == 0 {
+		return "N/A"
+	}
+	order := []string{"SSLv2", "SSLv3", "TLSv1.0", "TLSv1.1", "TLSv1.2", "TLSv1.3"}
+	var parts []string
+	for _, ver := range order {
+		ciphers, ok := cpp[ver]
+		if !ok {
+			continue
+		}
+		names := make([]string, 0, len(ciphers))
+		for _, c := range ciphers {
+			names = append(names, c.Name)
+		}
+		parts = append(parts, ver+": "+strings.Join(names, " "))
+	}
+	if len(parts) == 0 {
+		return "N/A"
+	}
+	return strings.Join(parts, "; ")
 }
 
 func stringInSlice(s string, list []string) bool {

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -77,7 +77,41 @@ func PrintClusterResults(results scanner.ScanResults) {
 					}
 				}
 			}
+			printCiphersPerProto(portResult)
 			fmt.Printf("\n")
+		}
+	}
+}
+
+var tlsVersionOrder = []string{"SSLv2", "SSLv3", "TLSv1.0", "TLSv1.1", "TLSv1.2", "TLSv1.3"}
+
+func printCiphersPerProto(pr scanner.PortResult) {
+	if len(pr.TlsCiphersPerProto) == 0 {
+		return
+	}
+	fmt.Printf("    Ciphers per Protocol:\n")
+	for _, ver := range tlsVersionOrder {
+		ciphers, ok := pr.TlsCiphersPerProto[ver]
+		if !ok {
+			continue
+		}
+		fmt.Printf("      %s: (%d ciphers)\n", ver, len(ciphers))
+		for _, c := range ciphers {
+			extra := ""
+			if c.KeyExch != "" || c.Bits != "" {
+				parts := []string{}
+				if c.KeyExch != "" {
+					parts = append(parts, c.KeyExch)
+				}
+				if c.Encrypt != "" {
+					parts = append(parts, c.Encrypt)
+				}
+				if c.Bits != "" {
+					parts = append(parts, c.Bits+" bits")
+				}
+				extra = " (" + strings.Join(parts, ", ") + ")"
+			}
+			fmt.Printf("        %-45s %s%s\n", c.Name, c.Strength, extra)
 		}
 	}
 }
@@ -98,20 +132,37 @@ func PrintParsedResults(results scanner.ScanResults) {
 				for _, version := range portResult.TlsVersions {
 					fmt.Printf("|   %s:\n", version)
 				}
-				if len(portResult.TlsCiphers) > 0 {
-					fmt.Printf("|   ciphers:\n")
-					for _, cipher := range portResult.TlsCiphers {
-						strength := portResult.TlsCipherStrength[cipher]
-						if strength != "" {
-							fmt.Printf("|     %s - %s\n", cipher, strength)
+			if len(portResult.TlsCiphers) > 0 {
+				fmt.Printf("|   ciphers:\n")
+				for _, cipher := range portResult.TlsCiphers {
+					strength := portResult.TlsCipherStrength[cipher]
+					if strength != "" {
+						fmt.Printf("|     %s - %s\n", cipher, strength)
+					} else {
+						fmt.Printf("|     %s\n", cipher)
+					}
+				}
+			}
+			if len(portResult.TlsCiphersPerProto) > 0 {
+				fmt.Println("| cipher-per-proto:")
+				for _, ver := range tlsVersionOrder {
+					ciphers, ok := portResult.TlsCiphersPerProto[ver]
+					if !ok {
+						continue
+					}
+					fmt.Printf("|   %s: (%d ciphers)\n", ver, len(ciphers))
+					for _, c := range ciphers {
+						if c.KeyExch != "" {
+							fmt.Printf("|     %-45s %-6s  %s %s\n", c.Name, c.KeyExch, c.Encrypt, c.Bits)
 						} else {
-							fmt.Printf("|     %s\n", cipher)
+							fmt.Printf("|     %s - %s\n", c.Name, c.Strength)
 						}
 					}
 				}
 			}
 		}
 	}
+}
 }
 
 func PrintPQCClusterResults(results scanner.ScanResults) {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -24,7 +24,7 @@ type portScanResult struct {
 	result    PortResult
 }
 
-func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client) ScanResults {
+func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client, cipherPerProto bool) ScanResults {
 	defer timing.Timings.Track("performClusterScan", "")()
 	startTime := time.Now()
 
@@ -210,7 +210,7 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 	fmt.Printf("\n=== DISCOVERY COMPLETE: %d pods -> %d scan jobs (%d deduplicated), %d skipped ===\n\n",
 		progress.discoveredPods.Load(), len(scanJobs), beforeDedup-len(scanJobs), progress.skippedPorts.Load())
 
-	batchResults := batchScan(scanJobs, concurrentScans, client, tlsConfig)
+	batchResults := batchScan(scanJobs, concurrentScans, client, tlsConfig, cipherPerProto)
 
 	results := assembleResults(startTime, totalIPs, tlsConfig, localhostResults, batchResults)
 
@@ -232,7 +232,7 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 
 // Scan runs a batch testssl.sh scan on pre-built scan jobs.
 // Used by --targets and single-host paths (no k8s discovery needed).
-func Scan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile) ScanResults {
+func Scan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile, cipherPerProto bool) ScanResults {
 	defer timing.Timings.Track("scan", "")()
 	startTime := time.Now()
 
@@ -247,7 +247,7 @@ func Scan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8
 	fmt.Printf("MAX_PARALLEL: %d\n", concurrentScans)
 	fmt.Printf("========================================\n\n")
 
-	batchResults := batchScan(jobs, concurrentScans, client, tlsConfig)
+	batchResults := batchScan(jobs, concurrentScans, client, tlsConfig, cipherPerProto)
 	results := assembleResults(startTime, 0, tlsConfig, batchResults)
 
 	duration := time.Since(startTime)
@@ -265,7 +265,7 @@ func Scan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8
 	return results
 }
 
-func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile) []portScanResult {
+func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile, cipherPerProto bool) []portScanResult {
 	if len(jobs) == 0 {
 		return nil
 	}
@@ -300,7 +300,11 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "testssl.sh", "-p", "-s", "-f",
+	testsslArgs := []string{"-p", "-s", "-f"}
+	if cipherPerProto {
+		testsslArgs = append(testsslArgs, "-E")
+	}
+	testsslArgs = append(testsslArgs,
 		"--connect-timeout", "5",
 		"--openssl-timeout", "5",
 		"--file", targetsFile,
@@ -308,6 +312,7 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 		"--warnings", "off",
 		"--color", "0",
 		"--parallel")
+	cmd := exec.CommandContext(ctx, "testssl.sh", testsslArgs...)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("MAX_PARALLEL=%d", concurrentScans))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -358,6 +363,10 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 
 		portResult.TlsVersions, portResult.TlsCiphers, portResult.TlsCipherStrength = ExtractTLSInfo(scanResult)
 		portResult.TlsKeyExchange = ExtractKeyExchangeFromTestSSL(portData)
+
+		if cipherPerProto {
+			portResult.TlsCiphersPerProto = ExtractCiphersPerProto(portData)
+		}
 
 		PopulatePQCFields(&portResult)
 

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -14,10 +14,12 @@ import (
 const mockTestSSLScript = `#!/bin/bash
 JSONFILE=""
 TARGETS_FILE=""
+CIPHER_PER_PROTO=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --jsonfile) JSONFILE="$2"; shift 2;;
         --file) TARGETS_FILE="$2"; shift 2;;
+        -E) CIPHER_PER_PROTO=true; shift;;
         *) shift;;
     esac
 done
@@ -32,6 +34,12 @@ while IFS= read -r target; do
     printf '{"id":"TLS1_3","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
     printf '{"id":"FS","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
     printf '{"id":"FS_KEMs","ip":"%s/%s","port":"%s","severity":"OK","finding":"x25519mlkem768"}' "$ip" "$ip" "$port"
+    if [ "$CIPHER_PER_PROTO" = true ]; then
+        printf ',{"id":"cipher-tls1_2-x0033","ip":"%s/%s","port":"%s","severity":"OK","finding":"TLS_RSA_WITH_AES_128_CBC_SHA RSA AES 128"}' "$ip" "$ip" "$port"
+        printf ',{"id":"cipher-tls1_2-xc02f","ip":"%s/%s","port":"%s","severity":"OK","finding":"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 ECDH AESGCM 128"}' "$ip" "$ip" "$port"
+        printf ',{"id":"cipher-tls1_3-x1301","ip":"%s/%s","port":"%s","severity":"OK","finding":"TLS_AES_128_GCM_SHA256 ECDH AESGCM 128"}' "$ip" "$ip" "$port"
+        printf ',{"id":"cipher-tls1_3-x1302","ip":"%s/%s","port":"%s","severity":"OK","finding":"TLS_AES_256_GCM_SHA384 ECDH AESGCM 256"}' "$ip" "$ip" "$port"
+    fi
 done < "$TARGETS_FILE"
 printf ']'
 } > "$JSONFILE"
@@ -71,7 +79,7 @@ func TestScanWithMockTestSSL(t *testing.T) {
 		{IP: "10.0.0.1", Port: 443},
 		{IP: "10.0.0.2", Port: 8443},
 	}
-	results := Scan(jobs, 2, nil, nil)
+	results := Scan(jobs, 2, nil, nil, false)
 
 	if results.ScannedIPs != 2 {
 		t.Fatalf("expected 2 scanned IPs, got %d", results.ScannedIPs)
@@ -95,7 +103,7 @@ func TestScanPQCEnrichment(t *testing.T) {
 	installMockTestSSL(t)
 
 	jobs := []ScanJob{{IP: "10.0.0.1", Port: 443}}
-	results := Scan(jobs, 1, nil, nil)
+	results := Scan(jobs, 1, nil, nil, false)
 
 	pr := results.IPResults[0].PortResults[0]
 
@@ -128,7 +136,7 @@ func TestPerformClusterScanWithMockPods(t *testing.T) {
 		makePod("no-ports", "openshift-console", "10.128.0.30"),
 	}
 
-	results := PerformClusterScan(pods, 2, nil)
+	results := PerformClusterScan(pods, 2, nil, false)
 
 	if results.ScannedIPs != 3 {
 		t.Errorf("expected 3 scanned IPs (including no-ports), got %d", results.ScannedIPs)

--- a/internal/scanner/testssl.go
+++ b/internal/scanner/testssl.go
@@ -303,6 +303,85 @@ func ExtractKeyExchangeFromTestSSL(jsonData []byte) *KeyExchangeInfo {
 	return keyExchange
 }
 
+// ExtractCiphersPerProto parses testssl.sh -E (--cipher-per-proto) JSON
+// output and returns a map from TLS version (e.g. "TLSv1.2") to the list
+// of individual ciphers reported for that protocol.
+func ExtractCiphersPerProto(jsonData []byte) map[string][]CipherDetail {
+	var rawData []map[string]interface{}
+	if err := json.Unmarshal(jsonData, &rawData); err != nil {
+		log.Printf("Error parsing testssl.sh JSON for cipher-per-proto: %v", err)
+		return nil
+	}
+
+	result := make(map[string][]CipherDetail)
+
+	for _, finding := range rawData {
+		id, _ := finding["id"].(string)
+		findingValue, _ := finding["finding"].(string)
+		severity, _ := finding["severity"].(string)
+
+		if findingValue == "" || findingValue == "not offered" {
+			continue
+		}
+
+		isCipherEntry := (strings.HasPrefix(id, "cipher-") || strings.HasPrefix(id, "cipher_")) &&
+			!strings.Contains(id, "order") &&
+			!strings.Contains(id, "list") &&
+			!strings.Contains(id, "score")
+		if !isCipherEntry {
+			continue
+		}
+
+		tlsVersion := extractTLSVersionFromCipherID(id, finding)
+		if tlsVersion == "" {
+			continue
+		}
+
+		detail := parseCipherFinding(findingValue, severity)
+		if detail.Name == "" {
+			continue
+		}
+
+		result[tlsVersion] = append(result[tlsVersion], detail)
+	}
+
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
+// parseCipherFinding extracts cipher details from a testssl.sh finding string.
+// testssl -E findings typically look like:
+//
+//	"TLS_AES_128_GCM_SHA256  ECDH 253  AESGCM  128"
+//
+// or simply:
+//
+//	"TLS_AES_128_GCM_SHA256"
+func parseCipherFinding(finding, severity string) CipherDetail {
+	fields := strings.Fields(finding)
+	if len(fields) == 0 {
+		return CipherDetail{}
+	}
+
+	detail := CipherDetail{
+		Name:     fields[len(fields)-1],
+		Strength: mapSeverityToStrength(severity),
+	}
+
+	if len(fields) >= 4 {
+		detail.Name = fields[0]
+		detail.KeyExch = fields[1]
+		detail.Encrypt = fields[len(fields)-2]
+		detail.Bits = fields[len(fields)-1]
+	} else if len(fields) >= 2 {
+		detail.Name = fields[0]
+	}
+
+	return detail
+}
+
 func IsKEMGroup(name string) bool {
 	lower := strings.ToLower(name)
 	return strings.Contains(lower, "mlkem") ||

--- a/internal/scanner/testssl_integration_test.go
+++ b/internal/scanner/testssl_integration_test.go
@@ -33,7 +33,7 @@ func TestIntegrationSingleTarget(t *testing.T) {
 	jobs := []ScanJob{{IP: tgt.ip, Port: tgt.port}}
 
 	start := time.Now()
-	results := batchScan(jobs, 1, nil, nil)
+	results := batchScan(jobs, 1, nil, nil, false)
 	elapsed := time.Since(start)
 
 	t.Logf("Single target %s (%s:%d): %v", tgt.desc, tgt.ip, tgt.port, elapsed)
@@ -73,7 +73,7 @@ func TestIntegrationBatchTargets(t *testing.T) {
 	}
 
 	start := time.Now()
-	results := batchScan(jobs, 4, nil, nil)
+	results := batchScan(jobs, 4, nil, nil, false)
 	elapsed := time.Since(start)
 
 	t.Logf("Batch %d targets (MAX_PARALLEL=4): %v (%.1fs/target)",
@@ -102,12 +102,12 @@ func TestIntegrationParallelScaling(t *testing.T) {
 
 	t.Log("--- Sequential run (MAX_PARALLEL=1) ---")
 	start := time.Now()
-	seqResults := batchScan(jobs, 1, nil, nil)
+	seqResults := batchScan(jobs, 1, nil, nil, false)
 	sequential := time.Since(start)
 
 	t.Log("--- Parallel run (MAX_PARALLEL=", len(jobs), ") ---")
 	start = time.Now()
-	parResults := batchScan(jobs, len(jobs), nil, nil)
+	parResults := batchScan(jobs, len(jobs), nil, nil, false)
 	parallel := time.Since(start)
 
 	speedup := sequential.Seconds() / parallel.Seconds()

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -112,6 +112,7 @@ type PortResult struct {
 	TlsVersions                  []string                   `json:"tls_versions,omitempty"`
 	TlsCiphers                   []string                   `json:"tls_ciphers,omitempty"`
 	TlsCipherStrength            map[string]string          `json:"tls_cipher_strength,omitempty"`
+	TlsCiphersPerProto           map[string][]CipherDetail  `json:"tls_ciphers_per_proto,omitempty"`
 	TlsKeyExchange               *KeyExchangeInfo           `json:"tls_key_exchange,omitempty"`
 	Error                        string                     `json:"error,omitempty"`
 	Status                       ScanStatus                 `json:"status"`
@@ -125,6 +126,14 @@ type PortResult struct {
 	MLKEMCiphers                 []string                   `json:"mlkem_kems,omitempty"`
 	AllKEMs                      []string                   `json:"all_kems,omitempty"`
 	TLSReadiness                 *TLSReadiness              `json:"tls_readiness,omitempty"`
+}
+
+type CipherDetail struct {
+	Name     string `json:"name"`
+	KeyExch  string `json:"key_exchange,omitempty"`
+	Encrypt  string `json:"encryption,omitempty"`
+	Bits     string `json:"bits,omitempty"`
+	Strength string `json:"strength"`
 }
 
 type TLSConfigComplianceResult struct {


### PR DESCRIPTION
This adds a -E flag to tls-scanner. Enabling per proto cipher scans. This mode adds about 10% of scan overhead

## Benchmark
```
========================================
         BENCHMARK RESULTS
========================================

  Targets:                     100 known TLS hosts
  Parallelism:                 20

  --- Timing ---
  Base (no -E):                755635 ms  (7.55 s/target)
  With -E:                     843228 ms  (8.43 s/target)
  Difference:                  87593 ms  (11.5%  -E is slower)
  Ratio (-E / base):           1.11x
  ```