### PR TITLE
Use native cross-compilation in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
+FROM --platform=$BUILDPLATFORM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.21 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -7,7 +10,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN make
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make
 
 FROM registry.ci.openshift.org/ocp/4.21:base-rhel9
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,7 @@
-FROM docker.io/library/golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.24 AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -7,7 +10,7 @@ RUN go mod download
 
 COPY . ./
 
-RUN make
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH make
 
 FROM registry.fedoraproject.org/fedora:latest
 


### PR DESCRIPTION
## Summary

- Pin the builder stage to the build host platform via `--platform=$BUILDPLATFORM` and pass `GOOS`/`GOARCH` to Go so the compiler runs natively instead of under QEMU emulation
- Applies to both `Dockerfile` and `Dockerfile.local`
- Cuts multi-arch build times from 30+ minutes to under a minute on cross-platform hosts (e.g. building linux/amd64 on Apple Silicon)

## Test plan

- [ ] Build with `podman build --platform linux/amd64 -t tls-scanner:test -f Dockerfile.local .` on an arm64 host and verify the binary is amd64
- [ ] Build with `podman build --platform linux/arm64 -t tls-scanner:test -f Dockerfile.local .` on an amd64 host and verify the binary is arm64
- [ ] Verify single-platform build still works (no `--platform` flag)