### PR TITLE
fix(Dockerfile): remove go from runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG TARGETARCH
 ARG TESTSSL_VERSION=3.2.2
 
 RUN dnf -y update && \
-    dnf install -y --allowerasing binutils file go podman runc jq skopeo tar lsof openssl bash && \
+    dnf install -y --allowerasing binutils file podman runc jq skopeo tar lsof openssl bash && \
     dnf clean all
 
 RUN wget -O "openshift-client-linux-${OC_VERSION}.tar.gz" "https://mirror.openshift.com/pub/openshift-v4/${TARGETARCH}/clients/ocp/${OC_VERSION}/openshift-client-linux.tar.gz" && \


### PR DESCRIPTION
Removing go from the dnf install line would avoid the entire openssl-devel dependency chain, which can conflict with the one already present in the base image and also make the image smaller.

Related issue [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/78210/rehearse-78210-periodic-ci-openshift-tls-scanner-main-periodic-tls13-pqc-readiness/2047226627229749248#1:build-log.txt%3A225-232):

```
error: Could not depsolve transaction; 1 problem detected:
 Problem: openssl-devel-1:3.5.5-1.el9.i686 from rhel-9-appstream  does not belong to a distupgrade repository
  - package golang-1.25.7-1.el9.x86_64 from rhel-9-appstream requires openssl-devel, but none of the providers can be installed
  - package openssl-devel-1:3.5.5-1.el9.x86_64 from rhel-9-appstream requires openssl-libs(x86-64) = 1:3.5.5-1.el9, but none of the providers can be installed
  - cannot install both openssl-libs-1:3.5.5-1.el9.x86_64 from rhel-9-baseos and openssl-libs-1:3.5.5-2.el9_8.x86_64 from @System
  - package openssl-1:3.5.5-2.el9_8.x86_64 from @System requires openssl-libs(x86-64) = 1:3.5.5-2.el9_8, but none of the providers can be installed
  - cannot install the best candidate for the job
  - conflicting requests
 ```
