### PR TITLE
Fix Dockerfile.local Go version to match go.mod

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 
 ARG TARGETOS=linux
 ARG TARGETARCH=amd64


### PR DESCRIPTION
## Summary

- Update `Dockerfile.local` builder stage from `golang:1.24` to `golang:1.25` to match `go.mod` requirement
- Local builds would fail without this since the module requires Go 1.25

## Test plan

- [ ] `podman build -f Dockerfile.local .` succeeds