### PR TITLE
CNF-23786: Add --dry-run flag to preview scan targets without scanning

### DIFF
--- a/cmd/tls-scanner/main.go
+++ b/cmd/tls-scanner/main.go
@@ -69,6 +69,7 @@ func run(args []string) (exitCode int) {
 	logFile := fs.String("log-file", "", "Redirect all log output to the specified file")
 	pqcCheck := fs.Bool("pqc-check", false, "Quick check for TLS 1.3 and ML-KEM (post-quantum) support only")
 	timingFile := fs.String("timing-file", "", "Output timing report to specified file in artifact-dir")
+	dryRun := fs.Bool("dry-run", false, "Discover scan targets and print them without scanning")
 	showVersion := fs.Bool("version", false, "Print version and exit")
 	logLevel := fs.String("log-level", "info", "Log level: debug, info, warn, error")
 
@@ -130,7 +131,7 @@ func run(args []string) (exitCode int) {
 		}
 	}()
 
-	if !scanner.IsTestSSLInstalled() {
+	if !*dryRun && !scanner.IsTestSSLInstalled() {
 		slog.Error("testssl.sh is not installed or not in the system's PATH")
 		return 1
 	}
@@ -166,6 +167,11 @@ func run(args []string) (exitCode int) {
 		if len(jobs) == 0 {
 			slog.Error("no valid targets found in --targets flag")
 			return 1
+		}
+
+		if *dryRun {
+			output.PrintDryRunTargets(jobs)
+			return 0
 		}
 
 		scanResults := scanner.Scan(jobs, *concurrentScans, nil, nil, policy)
@@ -247,6 +253,12 @@ func run(args []string) (exitCode int) {
 		}
 	}
 
+	if len(pods) > 0 && *dryRun {
+		discovery := scanner.DiscoverTargets(pods, *concurrentScans, client)
+		output.PrintDryRunResults(discovery)
+		return 0
+	}
+
 	if len(pods) > 0 {
 		scanResults := scanner.PerformClusterScan(pods, *concurrentScans, client, policy)
 		finalScanResults = &scanResults
@@ -271,6 +283,12 @@ func run(args []string) (exitCode int) {
 	}
 
 	jobs := []scanner.ScanJob{{IP: normalizeHost(*host), Port: portNum}}
+
+	if *dryRun {
+		output.PrintDryRunTargets(jobs)
+		return 0
+	}
+
 	scanResults := scanner.Scan(jobs, *concurrentScans, client, nil, policy)
 	finalScanResults = &scanResults
 

--- a/internal/output/dryrun.go
+++ b/internal/output/dryrun.go
@@ -1,0 +1,89 @@
+package output
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+
+	"github.com/openshift/tls-scanner/internal/scanner"
+)
+
+func PrintDryRunResults(discovery scanner.DiscoveryResults) {
+	skipped := discovery.SkippedPorts()
+
+	statusCounts := map[scanner.ScanStatus]int{}
+	for _, s := range skipped {
+		statusCounts[s.Status]++
+	}
+
+	fmt.Printf(`========================================
+DRY RUN: Discovery complete
+========================================
+Scan targets:          %d
+Skipped (localhost):   %d
+Skipped (no ports):    %d
+Skipped (probe ports): %d
+========================================
+
+`, len(discovery.ScanJobs),
+		statusCounts[scanner.StatusLocalhostOnly],
+		statusCounts[scanner.StatusNoPorts],
+		statusCounts[scanner.StatusProbePort],
+	)
+
+	if len(discovery.ScanJobs) > 0 {
+		fmt.Printf("SCAN TARGETS:\n")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "IP\tPort\tPod Name\tNamespace\tComponent")
+		for _, job := range discovery.ScanJobs {
+			component := "N/A"
+			if job.Component != nil {
+				component = job.Component.Component
+			}
+			fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\n",
+				job.IP, job.Port, job.Pod.Name, job.Pod.Namespace, component)
+		}
+		w.Flush()
+	}
+
+	skippedWithPorts := 0
+	for _, s := range skipped {
+		if s.Status != scanner.StatusNoPorts {
+			skippedWithPorts++
+		}
+	}
+
+	if skippedWithPorts > 0 {
+		fmt.Printf("\nSKIPPED PORTS:\n")
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "IP\tPort\tPod Name\tNamespace\tStatus\tReason")
+		for _, s := range skipped {
+			if s.Status == scanner.StatusNoPorts {
+				continue
+			}
+			fmt.Fprintf(w, "%s\t%d\t%s\t%s\t%s\t%s\n",
+				s.IP, s.Port, s.PodName, s.PodNamespace,
+				s.Status, s.Reason)
+		}
+		w.Flush()
+	}
+}
+
+func PrintDryRunTargets(jobs []scanner.ScanJob) {
+	fmt.Printf(`========================================
+DRY RUN: %d targets
+========================================
+
+`, len(jobs))
+
+	if len(jobs) == 0 {
+		return
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "IP\tPort")
+	for _, job := range jobs {
+		fmt.Fprintf(w, "%s\t%d\n", job.IP, job.Port)
+	}
+	w.Flush()
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -24,40 +24,36 @@ type portScanResult struct {
 	result    PortResult
 }
 
-func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client, policy *ComponentPolicy) ScanResults {
-	defer timing.Timings.Track("performClusterScan", "")()
-	startTime := time.Now()
+type DiscoveryResults struct {
+	ScanJobs []ScanJob
+	Skipped  []portScanResult
+}
 
-	totalIPs := 0
-	for _, pod := range pods {
-		totalIPs += len(pod.IPs)
+func (d DiscoveryResults) SkippedPorts() []SkippedPort {
+	out := make([]SkippedPort, len(d.Skipped))
+	for i, s := range d.Skipped {
+		out[i] = SkippedPort{
+			IP:           s.ip,
+			Port:         s.result.Port,
+			PodName:      s.pod.Name,
+			PodNamespace: s.pod.Namespace,
+			Status:       s.result.Status,
+			Reason:       s.result.Reason,
+		}
 	}
+	return out
+}
+
+func DiscoverTargets(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client) DiscoveryResults {
+	defer timing.Timings.Track("discoverTargets", "")()
 
 	discoveryWorkers := max(2, concurrentScans/2)
-
-	fmt.Printf("========================================\n")
-	fmt.Printf("CLUSTER SCAN STARTING\n")
-	fmt.Printf("========================================\n")
-	fmt.Printf("Total Pods: %d\n", len(pods))
-	fmt.Printf("Total IPs: %d\n", totalIPs)
-	fmt.Printf("Discovery workers: %d\n", discoveryWorkers)
-	fmt.Printf("MAX_PARALLEL (testssl): %d\n", concurrentScans)
-	fmt.Printf("========================================\n\n")
 
 	progress := NewProgressTracker(len(pods))
 	progress.Start(15 * time.Second)
 
-	var tlsConfig *k8s.TLSSecurityProfile
-	if client != nil {
-		if config, err := client.GetTLSSecurityProfile(); err != nil {
-			slog.Warn("could not collect TLS security profiles", "error", err)
-		} else {
-			tlsConfig = config
-		}
-	}
-
 	var scanJobs []ScanJob
-	var localhostResults []portScanResult
+	var skipped []portScanResult
 	var mu sync.Mutex
 
 	discoveryChan := make(chan k8s.PodInfo, len(pods))
@@ -123,7 +119,7 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 					if len(openPorts) == 0 {
 						progress.PortSkipped()
 						mu.Lock()
-						localhostResults = append(localhostResults, portScanResult{
+						skipped = append(skipped, portScanResult{
 							ip:        ip,
 							pod:       pod,
 							component: component,
@@ -155,7 +151,7 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 								}
 								progress.PortSkipped()
 								mu.Lock()
-								localhostResults = append(localhostResults, portScanResult{
+								skipped = append(skipped, portScanResult{
 									ip: ip, pod: pod, component: component, result: pr,
 								})
 								mu.Unlock()
@@ -183,7 +179,7 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 							}
 							progress.PortSkipped()
 							mu.Lock()
-							localhostResults = append(localhostResults, portScanResult{
+							skipped = append(skipped, portScanResult{
 								ip: ip, pod: pod, component: component, result: pr,
 							})
 							mu.Unlock()
@@ -213,9 +209,42 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 	fmt.Printf("\n=== DISCOVERY COMPLETE: %d pods -> %d scan jobs (%d deduplicated), %d skipped ===\n\n",
 		progress.discoveredPods.Load(), len(scanJobs), beforeDedup-len(scanJobs), progress.skippedPorts.Load())
 
-	batchResults := batchScan(scanJobs, concurrentScans, client, tlsConfig, policy)
+	return DiscoveryResults{ScanJobs: scanJobs, Skipped: skipped}
+}
 
-	results := assembleResults(startTime, totalIPs, tlsConfig, localhostResults, batchResults)
+func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client, policy *ComponentPolicy) ScanResults {
+	defer timing.Timings.Track("performClusterScan", "")()
+	startTime := time.Now()
+
+	totalIPs := 0
+	for _, pod := range pods {
+		totalIPs += len(pod.IPs)
+	}
+
+	fmt.Printf(`========================================
+CLUSTER SCAN STARTING
+========================================
+Total Pods: %d
+Total IPs: %d
+MAX_PARALLEL (testssl): %d
+========================================
+
+`, len(pods), totalIPs, concurrentScans)
+
+	var tlsConfig *k8s.TLSSecurityProfile
+	if client != nil {
+		if config, err := client.GetTLSSecurityProfile(); err != nil {
+			slog.Warn("could not collect TLS security profiles", "error", err)
+		} else {
+			tlsConfig = config
+		}
+	}
+
+	discovery := DiscoverTargets(pods, concurrentScans, client)
+
+	batchResults := batchScan(discovery.ScanJobs, concurrentScans, client, tlsConfig, policy)
+
+	results := assembleResults(startTime, totalIPs, tlsConfig, discovery.Skipped, batchResults)
 
 	duration := time.Since(startTime)
 	fmt.Printf("\n========================================\n")
@@ -223,7 +252,7 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 	fmt.Printf("========================================\n")
 	fmt.Printf("Total IPs processed: %d\n", results.ScannedIPs)
 	fmt.Printf("Total ports scanned: %d\n", len(batchResults))
-	fmt.Printf("Total ports skipped: %d\n", progress.skippedPorts.Load())
+	fmt.Printf("Total ports skipped: %d\n", len(discovery.Skipped))
 	fmt.Printf("Total time: %v\n", duration)
 	if len(batchResults) > 0 {
 		fmt.Printf("Throughput: %.2f ports/min\n", float64(len(batchResults))/duration.Minutes())

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -159,6 +159,15 @@ type ScanJob struct {
 	Component *k8s.OpenshiftComponent
 }
 
+type SkippedPort struct {
+	IP           string
+	Port         int
+	PodName      string
+	PodNamespace string
+	Status       ScanStatus
+	Reason       string
+}
+
 var TLSVersionValueMap = map[string]int{
 	"TLSv1.0":      10,
 	"TLSv1.1":      11,


### PR DESCRIPTION
## Summary

- Extract discovery phase from `PerformClusterScan()` into reusable `DiscoverTargets()` function
- Add `--dry-run` flag that runs pod/port discovery only and prints a tabular summary of scan targets and skipped ports
- Works with `--all-pods`, `--targets`, and single-host modes
- Skips testssl.sh installation check when `--dry-run` is set since it is not needed for discovery

Jira: [CNF-23786](https://redhat.atlassian.net/browse/CNF-23786)

## Example output

```
$ tls-scanner --all-pods --dry-run --namespace-filter openshift-etcd

=== DISCOVERY COMPLETE: 6 pods -> 102 scan jobs (0 deduplicated), 38 skipped ===

========================================
DRY RUN: Discovery complete
========================================
Scan targets:          102
Skipped (localhost):   35
Skipped (no ports):    3
Skipped (probe ports): 0
========================================

SCAN TARGETS:
IP            Port   Pod Name               Namespace       Component
10.46.97.140  9107   etcd-cnfdt16-master-1  openshift-etcd  openshift-component
10.46.97.140  2380   etcd-cnfdt16-master-1  openshift-etcd  openshift-component
10.46.97.140  2379   etcd-cnfdt16-master-1  openshift-etcd  openshift-component
10.46.97.140  6443   etcd-cnfdt16-master-1  openshift-etcd  openshift-component
...

SKIPPED PORTS:
IP            Port   Pod Name               Namespace       Status          Reason
10.46.97.140  8797   etcd-cnfdt16-master-1  openshift-etcd  LOCALHOST_ONLY  Bound to 127.0.0.1, not accessible from pod IP
10.46.97.140  9537   etcd-cnfdt16-master-1  openshift-etcd  LOCALHOST_ONLY  Bound to 127.0.0.1, not accessible from pod IP
10.46.97.140  10248  etcd-cnfdt16-master-1  openshift-etcd  LOCALHOST_ONLY  Bound to 127.0.0.1, not accessible from pod IP
...
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `tls-scanner --all-pods --dry-run` prints target table and exits without scanning
- [x] `tls-scanner --all-pods --dry-run --namespace-filter openshift-etcd` filters correctly
- [x] `tls-scanner --targets 10.0.0.1:443 --dry-run` prints target list
- [x] `tls-scanner --dry-run` (single host default) prints single target
- [ ] Normal scan without `--dry-run` still works identically