### PR TITLE
(feat) Add template for specifying endpoint to scan

### DIFF
--- a/cmd/tls-scanner/main.go
+++ b/cmd/tls-scanner/main.go
@@ -63,6 +63,8 @@ func run(args []string) (exitCode int) {
 	componentFilter := fs.String("component-filter", "", "Filter pods by a comma-separated list of component names (only used with --all-pods)")
 	namespaceFilter := fs.String("namespace-filter", "", "Filter pods by a comma-separated list of namespaces (only used with --all-pods)")
 	targets := fs.String("targets", "", "A comma-separated list of host:port targets to scan")
+	templateFile := fs.String("template", "", "Path to a YAML file listing hosts and ports to scan (see --generate-template)")
+	generateTemplate := fs.String("generate-template", "", "Write a sample targets YAML template to this path and exit")
 	limitIPs := fs.Int("limit-ips", 0, "Limit the number of IPs to scan for testing purposes (0 = no limit)")
 	logFile := fs.String("log-file", "", "Redirect all log output to the specified file")
 	pqcCheck := fs.Bool("pqc-check", false, "Quick check for TLS 1.3 and ML-KEM (post-quantum) support only")
@@ -79,6 +81,15 @@ func run(args []string) (exitCode int) {
 	}
 
 	isPQCCheck = *pqcCheck
+
+	if *generateTemplate != "" {
+		if err := scanner.GenerateTemplate(*generateTemplate); err != nil {
+			log.Printf("Error writing template: %v", err)
+			return 1
+		}
+		fmt.Printf("Template written to %s\n", *generateTemplate)
+		return 0
+	}
 
 	policy := scanner.Policy()
 
@@ -144,6 +155,29 @@ func run(args []string) (exitCode int) {
 
 		if len(jobs) == 0 {
 			log.Print("Error: No valid targets found in --targets flag")
+			return 1
+		}
+
+		scanResults := scanner.Scan(jobs, *concurrentScans, nil, nil, policy)
+		finalScanResults = &scanResults
+
+		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
+			log.Printf("Error writing output files: %v", err)
+			return 1
+		}
+		if isPQCCheck {
+			output.PrintPQCClusterResults(scanResults)
+		} else if *jsonFile == "" && *csvFile == "" && *junitFile == "" {
+			output.PrintClusterResults(scanResults)
+		}
+
+		return
+	}
+
+	if *templateFile != "" {
+		jobs, err := scanner.LoadTemplate(*templateFile)
+		if err != nil {
+			log.Printf("Error loading template: %v", err)
 			return 1
 		}
 

--- a/internal/scanner/template.go
+++ b/internal/scanner/template.go
@@ -1,0 +1,91 @@
+package scanner
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ScanTemplate is the root document for a TLS scanner targets YAML file.
+type ScanTemplate struct {
+	Targets []TemplateTarget `yaml:"targets"`
+}
+
+// TemplateTarget groups one host with one or more TCP ports to scan.
+type TemplateTarget struct {
+	Host  string `yaml:"host"`
+	Ports []int  `yaml:"ports"`
+}
+
+const templateSample = `# TLS Scanner targets — commit beside your component to document TLS endpoints.
+# Run: tls-scanner --template this-file.yml
+#
+# "host" is any name or IP reachable from where you run the scanner (not pod IPs).
+# Typical OpenShift/Kubernetes values: Route hostname, Ingress host, or Service DNS
+# (e.g. mysvc.myns.svc.cluster.local). Replace the examples below with your real names.
+#
+targets:
+  - host: mycomponent-myproject.apps.cluster.example.com
+    ports:
+      - 443
+  - host: mycomponent.myproject.svc.cluster.local
+    ports:
+      - 443
+      - 8443
+`
+
+// GenerateTemplate writes a commented sample YAML file to path.
+func GenerateTemplate(path string) error {
+	return os.WriteFile(path, []byte(templateSample), 0644)
+}
+
+// LoadTemplate reads a YAML template from path and returns scan jobs (one per host:port).
+func LoadTemplate(path string) ([]ScanJob, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read template: %w", err)
+	}
+
+	var doc ScanTemplate
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parse template YAML: %w", err)
+	}
+
+	if len(doc.Targets) == 0 {
+		return nil, fmt.Errorf("template has no targets")
+	}
+
+	var jobs []ScanJob
+	for ti, t := range doc.Targets {
+		host := strings.TrimSpace(t.Host)
+		if host == "" {
+			return nil, fmt.Errorf("targets[%d]: host is required", ti)
+		}
+		host = normalizeTemplateHost(host)
+		if len(t.Ports) == 0 {
+			return nil, fmt.Errorf("targets[%d] (%s): at least one port is required", ti, host)
+		}
+		for pi, port := range t.Ports {
+			if port < 1 || port > 65535 {
+				return nil, fmt.Errorf("targets[%d] (%s): invalid port %d at index %d (want 1-65535)", ti, host, port, pi)
+			}
+			jobs = append(jobs, ScanJob{IP: host, Port: port})
+		}
+	}
+
+	if len(jobs) == 0 {
+		return nil, fmt.Errorf("template produced no scan jobs")
+	}
+
+	return jobs, nil
+}
+
+func normalizeTemplateHost(host string) string {
+	host = strings.TrimSpace(host)
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") && len(host) >= 2 {
+		return host[1 : len(host)-1]
+	}
+	return host
+}

--- a/internal/scanner/template_test.go
+++ b/internal/scanner/template_test.go
@@ -1,0 +1,135 @@
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadTemplate_valid(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "targets.yml")
+	content := `targets:
+  - host: mysvc.myns.svc.cluster.local
+    ports:
+      - 443
+      - 8443
+  - host: myroute-myproject.apps.example.com
+    ports:
+      - 443
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	jobs, err := LoadTemplate(path)
+	if err != nil {
+		t.Fatalf("LoadTemplate: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("got %d jobs, want 3", len(jobs))
+	}
+	want := []struct {
+		host string
+		port int
+	}{
+		{"mysvc.myns.svc.cluster.local", 443},
+		{"mysvc.myns.svc.cluster.local", 8443},
+		{"myroute-myproject.apps.example.com", 443},
+	}
+	for i := range want {
+		if i >= len(jobs) {
+			break
+		}
+		if jobs[i].IP != want[i].host || jobs[i].Port != want[i].port {
+			t.Errorf("jobs[%d] = %s:%d, want %s:%d", i, jobs[i].IP, jobs[i].Port, want[i].host, want[i].port)
+		}
+	}
+}
+
+func TestLoadTemplate_missingHost(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "targets.yml")
+	content := `targets:
+  - host: ""
+    ports:
+      - 443
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadTemplate(path)
+	if err == nil {
+		t.Fatal("expected error for empty host")
+	}
+}
+
+func TestLoadTemplate_invalidPort(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "targets.yml")
+	content := `targets:
+  - host: 127.0.0.1
+    ports:
+      - 0
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadTemplate(path)
+	if err == nil {
+		t.Fatal("expected error for invalid port")
+	}
+}
+
+func TestLoadTemplate_emptyFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.yml")
+	if err := os.WriteFile(path, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadTemplate(path)
+	if err == nil {
+		t.Fatal("expected error for empty template")
+	}
+}
+
+func TestLoadTemplate_noPorts(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "targets.yml")
+	content := `targets:
+  - host: 127.0.0.1
+    ports: []
+`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadTemplate(path)
+	if err == nil {
+		t.Fatal("expected error when ports is empty")
+	}
+}
+
+func TestGenerateTemplate(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.yml")
+	if err := GenerateTemplate(path); err != nil {
+		t.Fatal(err)
+	}
+	jobs, err := LoadTemplate(path)
+	if err != nil {
+		t.Fatalf("LoadTemplate generated file: %v", err)
+	}
+	if len(jobs) != 3 {
+		t.Fatalf("generated template: got %d jobs, want 3", len(jobs))
+	}
+}


### PR DESCRIPTION
Adds the ability to create a template containing the ports to scan in tls-scanner. This template is meant to live in the target code's repository and is consumed by the tls-scanner.

## Example template:
```
# "host" is any name or IP reachable from where you run the scanner (not pod IPs).
# Typical OpenShift/Kubernetes values: Route hostname, Ingress host, or Service DNS
# (e.g. mysvc.myns.svc.cluster.local). Replace the examples below with your real names.
#
targets:
  - host: mycomponent-myproject.apps.cluster.example.com
    ports:
      - 443
  - host: mycomponent.myproject.svc.cluster.local
    ports:
      - 443
      - 8443
```

## New Flags:
```
  -generate-template string
        Write a sample targets YAML template to this path and exit
  -template string
        Path to a YAML file listing hosts and ports to scan (see --generate-template)
```
-generate-template generates a template with the same contents as the example above.
