### PR TITLE
Allow override of BUILD_PLATFORM

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Set these environment variables in your CI job:
 - `KUBECONFIG`: Path to the kubeconfig file for the ephemeral test cluster.
 - `JOB_TEMPLATE_FILE`: (Optional) Path to the Job manifest template used by `deploy.sh deploy` (default: `scanner-job.yaml.template`). For host-based scanning, use a template that runs with host network access (e.g. `scanner-job-microshift.yaml.template`).
 - `SCAN_MODE`: (Optional) `pod` (default) or `host`. **Pod mode** discovers pods in the cluster and scans their TLS ports. **Host mode** is for environments where core components (API server, etcd, kubelet) run on the host rather than in pods—e.g. single-node or edge setups such as MicroShift. Use a job template with `hostNetwork: true` and set `SCAN_MODE=host` so the scanner runs on the host and can reach those services.
+- `BUILD_PLATFORM` (Optional) The architecture(s) to build for.
 
 #### 2. Build and Push the Image
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -40,7 +40,7 @@ SCAN_MODE=${SCAN_MODE:-"pod"}
 JOB_NAME="tls-scanner-job"
 LIMIT_IPS="${LIMIT_IPS:-0}"  # Limit number of IPs to scan (0 = no limit, useful for testing)
 # Architectures to build container images for
-BUILD_PLATFORMS="linux/amd64,linux/arm64,linux/s390x,linux/ppc64le"
+BUILD_PLATFORMS="${BUILD_PLATFORMS:-linux/amd64,linux/arm64,linux/s390x,linux/ppc64le}"
 
 # TLS test configuration
 TLS_TEST_TIMEOUT=${TLS_TEST_TIMEOUT:-600}  # 10 minutes default, configurable


### PR DESCRIPTION
We don't need to build for all platforms if we already know what we're targeting.
