### PR TITLE
fix #58: Honor pod labels for identifiying a component

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The scanner binary accepts the following command-line options. These are configu
 - `-port <port>` - Target port to scan (default: 443)
 - `-targets <host:port,...>` - Comma-separated list of host:port targets to scan
 - `-all-pods` - Scan all pods in the cluster (requires cluster access)
-- `-component-filter <names>` - Filter pods by component name (comma-separated, used with -all-pods)
+- `-component-filter <names>` - Filter pods by component name (comma-separated, used with -all-pods)*
 - `-namespace-filter <names>` - Filter pods by namespace (comma-separated, used with -all-pods)
 - `-limit-ips <num>` - Cap number of IPs to scan, for testing (0 = no limit)
 - `-pqc-check` - Check for TLS 1.3 + ML-KEM (post-quantum) support; exits non-zero on failure
@@ -189,3 +189,13 @@ The scanner binary accepts the following command-line options. These are configu
 - `-log-file <file>` - Redirect all log output to the specified file
 - `-timing-file <file>` - Write timing report to specified file in artifact-dir
 - `-version` - Print version and exit
+
+
+**Note**
+
+`-component-filter` identifies component name according to the following order:
+1. pod.labels['app']
+2. pod.labels['component']
+3. pod.labels['app.kubernetes.io/name']
+4. container.Name
+5. name determined from container.Image 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -142,7 +142,7 @@ func (c *Client) FilterPodsByComponent(pods []PodInfo, componentFilter string) [
 		if pod.Pod != nil && len(pod.Pod.Spec.Containers) > 0 {
 			componentName = c.extractComponentFromPod(*pod.Pod, pod.Pod.Spec.Containers[0])
 		} else {
-			log.Printf("Warning: pod %s/%s has no pod or container info", pod.Namespace, pod.Name)
+			slog.Warn("pod has no pod or container info", "namespace", pod.Namespace, "name", pod.Name)
 			continue
 		}
 

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -137,12 +137,16 @@ func (c *Client) FilterPodsByComponent(pods []PodInfo, componentFilter string) [
 
 	var filtered []PodInfo
 	for _, pod := range pods {
-		component, err := c.GetOpenshiftComponentFromImage(pod.Image)
-		if err != nil {
-			slog.Warn("could not get component for image", "image", pod.Image, "error", err)
+		// Extract component from pod labels (or fall back to image parsing)
+		var componentName string
+		if pod.Pod != nil && len(pod.Pod.Spec.Containers) > 0 {
+			componentName = c.extractComponentFromPod(*pod.Pod, pod.Pod.Spec.Containers[0])
+		} else {
+			log.Printf("Warning: pod %s/%s has no pod or container info", pod.Namespace, pod.Name)
 			continue
 		}
-		if _, ok := filterSet[component.Component]; ok {
+
+		if _, ok := filterSet[componentName]; ok {
 			filtered = append(filtered, pod)
 		}
 	}

--- a/internal/k8s/component.go
+++ b/internal/k8s/component.go
@@ -27,21 +27,28 @@ func (c *Client) GetOpenshiftComponentFromImage(image string) (*OpenshiftCompone
 // preferring pod labels for the component name but using image metadata for
 // source location and maintainer information.
 func (c *Client) GetOpenshiftComponentFromPod(pod v1.Pod) (*OpenshiftComponent, error) {
-	// First get the base component info from the image
-	image := ""
-	if len(pod.Spec.Containers) > 0 {
-		image = pod.Spec.Containers[0].Image
+	if len(pod.Spec.Containers) == 0 {
+		return nil, fmt.Errorf("pod has no containers")
 	}
 
-	component, err := c.GetOpenshiftComponentFromImage(image)
-	if err != nil {
-		return nil, err
+	image := pod.Spec.Containers[0].Image
+	container := pod.Spec.Containers[0]
+
+	// Start with locally available pod data - no API calls needed
+	component := &OpenshiftComponent{
+		Component:           c.extractComponentFromPod(pod, container),
+		MaintainerComponent: c.extractMaintainerFromPod(pod),
+		IsBundle:            false,
 	}
 
-	// Override the component name with the value from pod labels
-	if len(pod.Spec.Containers) > 0 {
-		componentName := c.extractComponentFromPod(pod, pod.Spec.Containers[0])
-		component.Component = componentName
+	// Try to enhance with image metadata (source location)
+	// This attempts fast image reference parsing first, avoiding cluster-wide searches
+	imageComponent := c.parseOpenshiftComponentFromImageRef(image)
+	if imageComponent != nil {
+		component.SourceLocation = imageComponent.SourceLocation
+	} else {
+		// Fall back to simple registry extraction
+		component.SourceLocation = c.extractRegistryFromImage(image)
 	}
 
 	return component, nil

--- a/internal/k8s/component.go
+++ b/internal/k8s/component.go
@@ -23,6 +23,30 @@ func (c *Client) GetOpenshiftComponentFromImage(image string) (*OpenshiftCompone
 	return c.getComponentFromClusterMetadata(image)
 }
 
+// GetOpenshiftComponentFromPod extracts component information from a pod,
+// preferring pod labels for the component name but using image metadata for
+// source location and maintainer information.
+func (c *Client) GetOpenshiftComponentFromPod(pod v1.Pod) (*OpenshiftComponent, error) {
+	// First get the base component info from the image
+	image := ""
+	if len(pod.Spec.Containers) > 0 {
+		image = pod.Spec.Containers[0].Image
+	}
+
+	component, err := c.GetOpenshiftComponentFromImage(image)
+	if err != nil {
+		return nil, err
+	}
+
+	// Override the component name with the value from pod labels
+	if len(pod.Spec.Containers) > 0 {
+		componentName := c.extractComponentFromPod(pod, pod.Spec.Containers[0])
+		component.Component = componentName
+	}
+
+	return component, nil
+}
+
 func (c *Client) parseOpenshiftComponentFromImageRef(image string) *OpenshiftComponent {
 	if strings.Contains(image, "quay.io/openshift-release-dev") {
 		component := &OpenshiftComponent{

--- a/internal/k8s/component.go
+++ b/internal/k8s/component.go
@@ -129,6 +129,7 @@ func (c *Client) getComponentFromClusterMetadata(image string) (*OpenshiftCompon
 	}, nil
 }
 
+
 func (c *Client) extractComponentNameFromImage(image string) string {
 	parts := strings.Split(image, "/")
 	if len(parts) > 0 {
@@ -155,6 +156,13 @@ func (c *Client) extractRegistryFromImage(image string) string {
 	return strings.Split(image, "/")[0]
 }
 
+// extractComponentFromPod returns a component name for a pod based on the following order
+// of precedence:
+//   1. label named 'app' 
+//   2. label named 'component'
+//   3. label named 'app.kubernetes.io/name'
+//   4. container.Name
+//   5. name determined from container.Image 
 func (c *Client) extractComponentFromPod(pod v1.Pod, container v1.Container) string {
 	if component, exists := pod.Labels["app"]; exists {
 		return component

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -69,7 +69,11 @@ func DiscoverTargets(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client
 
 				var component *k8s.OpenshiftComponent
 				if client != nil && pod.Pod != nil {
-					component, _ = client.GetOpenshiftComponentFromPod(*pod.Pod)
+					var err error
+					component, err = client.GetOpenshiftComponentFromPod(*pod.Pod)
+					if err != nil {
+						slog.Warn("failed to extract component from pod", "namespace", pod.Namespace, "pod", pod.Name, "error", err)
+					}
 				}
 
 			specPorts, _ := k8s.DiscoverPortsFromPodSpec(pod.Pod)

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -68,8 +68,8 @@ func DiscoverTargets(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client
 				progress.PodDiscovered()
 
 				var component *k8s.OpenshiftComponent
-				if client != nil {
-					component, _ = client.GetOpenshiftComponentFromImage(pod.Image)
+				if client != nil && pod.Pod != nil {
+					component, _ = client.GetOpenshiftComponentFromPod(*pod.Pod)
 				}
 
 			specPorts, _ := k8s.DiscoverPortsFromPodSpec(pod.Pod)


### PR DESCRIPTION
This PR:
* fixes #58 by honoring a pod's labels when determining the component
* fixes the inconsistency between the component scanresult and componen-filter arg