### PR TITLE
Add --log-level flag with log/slog structured logging

### DIFF
--- a/cmd/tls-scanner/main.go
+++ b/cmd/tls-scanner/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -70,10 +70,32 @@ func run(args []string) (exitCode int) {
 	pqcCheck := fs.Bool("pqc-check", false, "Quick check for TLS 1.3 and ML-KEM (post-quantum) support only")
 	timingFile := fs.String("timing-file", "", "Output timing report to specified file in artifact-dir")
 	showVersion := fs.Bool("version", false, "Print version and exit")
+	logLevel := fs.String("log-level", "info", "Log level: debug, info, warn, error")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
 	}
+
+	var level slog.Level
+	if err := level.UnmarshalText([]byte(*logLevel)); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: invalid log level %q (valid: debug, info, warn, error)\n", *logLevel)
+		return 2
+	}
+	logOutput := os.Stderr
+	if *logFile != "" {
+		f, err := os.OpenFile(*logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: opening log file: %v\n", err)
+			return 1
+		}
+		defer func() {
+			if cerr := f.Close(); cerr != nil {
+				slog.Warn("failed to close log file", "error", cerr)
+			}
+		}()
+		logOutput = f
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(logOutput, &slog.HandlerOptions{Level: level})))
 
 	if *showVersion {
 		fmt.Printf("tls-scanner %s (commit: %s)\n", version, commit)
@@ -84,62 +106,50 @@ func run(args []string) (exitCode int) {
 
 	if *generateTemplate != "" {
 		if err := scanner.GenerateTemplate(*generateTemplate); err != nil {
-			log.Printf("Error writing template: %v", err)
+			slog.Error("writing template", "error", err)
 			return 1
 		}
 		fmt.Printf("Template written to %s\n", *generateTemplate)
 		return 0
 	}
 
-	policy := scanner.Policy()
+	policy, err := scanner.Policy()
+	if err != nil {
+		slog.Error("loading policy", "error", err)
+		return 1
+	}
 
 	defer func() {
 		if *timingFile != "" {
 			path := filepath.Join(*artifactDir, *timingFile)
 			if err := timing.Timings.WriteReport(path); err != nil {
-				log.Printf("Warning: Could not write timing report: %v", err)
+				slog.Warn("could not write timing report", "error", err)
 			} else {
-				log.Printf("Timing report written to %s", path)
+				slog.Info("timing report written", "path", path)
 			}
 		}
 	}()
 
-	if *logFile != "" {
-		f, err := os.OpenFile(*logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
-		if err != nil {
-			log.Printf("error opening file: %v", err)
-			return 1
-		}
-		defer func() {
-			if cerr := f.Close(); cerr != nil {
-				log.Printf("Warning: failed to close log file: %v", cerr)
-			}
-		}()
-		log.SetOutput(f)
-		log.Printf("Logging to file: %s", *logFile)
-	}
-
 	if !scanner.IsTestSSLInstalled() {
-		log.Print("Error: testssl.sh is not installed or not in the system's PATH.")
+		slog.Error("testssl.sh is not installed or not in the system's PATH")
 		return 1
 	}
 
 	if *concurrentScans == 0 {
 		*concurrentScans = runtime.NumCPU()
-		log.Printf("Concurrency: %d (from CPU count)", *concurrentScans)
+		slog.Info("concurrency set from CPU count", "workers", *concurrentScans)
 	} else if *concurrentScans < 0 {
-		log.Print("Error: Number of concurrent scans must be >= 0 (0 = auto)")
+		slog.Error("number of concurrent scans must be >= 0 (0 = auto)")
 		return 1
 	}
 
 	var client *k8s.Client
-	var err error
 	var pods []k8s.PodInfo
 
 	if *targets != "" {
 		targetList := strings.Split(*targets, ",")
 		if len(targetList) == 0 || (len(targetList) == 1 && targetList[0] == "") {
-			log.Print("Error: --targets flag provided but no targets were specified")
+			slog.Error("--targets flag provided but no targets were specified")
 			return 1
 		}
 
@@ -147,14 +157,14 @@ func run(args []string) (exitCode int) {
 		for _, t := range targetList {
 			hostValue, portValue, err := parseTarget(t)
 			if err != nil {
-				log.Printf("Warning: Skipping invalid target format: %s (expected host:port)", t)
+				slog.Warn("skipping invalid target format", "target", t, "expected", "host:port")
 				continue
 			}
 			jobs = append(jobs, scanner.ScanJob{IP: hostValue, Port: portValue})
 		}
 
 		if len(jobs) == 0 {
-			log.Print("Error: No valid targets found in --targets flag")
+			slog.Error("no valid targets found in --targets flag")
 			return 1
 		}
 
@@ -162,7 +172,7 @@ func run(args []string) (exitCode int) {
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
-			log.Printf("Error writing output files: %v", err)
+			slog.Error("writing output files", "error", err)
 			return 1
 		}
 		if isPQCCheck {
@@ -177,7 +187,7 @@ func run(args []string) (exitCode int) {
 	if *templateFile != "" {
 		jobs, err := scanner.LoadTemplate(*templateFile)
 		if err != nil {
-			log.Printf("Error loading template: %v", err)
+			slog.Error("loading template", "error", err)
 			return 1
 		}
 
@@ -185,7 +195,7 @@ func run(args []string) (exitCode int) {
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
-			log.Printf("Error writing output files: %v", err)
+			slog.Error("writing output files", "error", err)
 			return 1
 		}
 		if isPQCCheck {
@@ -200,24 +210,24 @@ func run(args []string) (exitCode int) {
 	if *allPods {
 		client, err = k8s.NewClient()
 		if err != nil {
-			log.Printf("Could not create kubernetes client for --all-pods: %v", err)
+			slog.Error("could not create kubernetes client for --all-pods", "error", err)
 			return 1
 		}
 
 		pods, err = client.GetAllPodsInfo()
 		if err != nil {
-			log.Printf("Error listing pods: %v", err)
+			slog.Error("listing pods", "error", err)
 			return 1
 		}
 		pods = client.FilterPodsByComponent(pods, *componentFilter)
 		pods = k8s.FilterPodsByNamespace(pods, *namespaceFilter)
 
 		if len(pods) == 0 {
-			log.Print("Warning: no pods found matching the given filters, nothing to scan")
+			slog.Warn("no pods found matching the given filters, nothing to scan")
 			return 0
 		}
 
-		log.Printf("Found %d pods to scan from the cluster.", len(pods))
+		slog.Info("pods to scan", "count", len(pods))
 
 		if *limitIPs > 0 {
 			totalIPs := 0
@@ -226,13 +236,13 @@ func run(args []string) (exitCode int) {
 			}
 
 			if totalIPs > *limitIPs {
-				log.Printf("Limiting scan to %d IPs (found %d total IPs)", *limitIPs, totalIPs)
+				slog.Info("limiting scan", "limit", *limitIPs, "found", totalIPs)
 				pods = scanner.LimitPodsToIPCount(pods, *limitIPs)
 				limitedTotal := 0
 				for _, pod := range pods {
 					limitedTotal += len(pod.IPs)
 				}
-				log.Printf("After limiting: %d pods with %d total IPs", len(pods), limitedTotal)
+				slog.Info("after limiting", "pods", len(pods), "ips", limitedTotal)
 			}
 		}
 	}
@@ -242,7 +252,7 @@ func run(args []string) (exitCode int) {
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
-			log.Printf("Error writing output files: %v", err)
+			slog.Error("writing output files", "error", err)
 			return 1
 		}
 		if isPQCCheck {
@@ -256,7 +266,7 @@ func run(args []string) (exitCode int) {
 
 	portNum, err := strconv.Atoi(*port)
 	if err != nil {
-		log.Printf("Invalid port: %s", *port)
+		slog.Error("invalid port", "port", *port)
 		return 1
 	}
 
@@ -265,7 +275,7 @@ func run(args []string) (exitCode int) {
 	finalScanResults = &scanResults
 
 	if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
-		log.Printf("Error writing output files: %v", err)
+		slog.Error("writing output files", "error", err)
 		return 1
 	}
 	if isPQCCheck {

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -20,13 +20,13 @@ import (
 func NewClient() (*Client, error) {
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		log.Printf("Could not load in-cluster config, falling back to kubeconfig: %v", err)
+		slog.Warn("could not load in-cluster config, falling back to kubeconfig", "error", err)
 		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 		config, err = clientcmd.BuildConfigFromFlags("", loadingRules.GetDefaultFilename())
 		if err != nil {
 			return nil, fmt.Errorf("could not get kubernetes config: %v", err)
 		}
-		log.Println("Successfully created Kubernetes client from kubeconfig file")
+		slog.Info("Successfully created Kubernetes client from kubeconfig file")
 	}
 
 	clientset, err := kubernetes.NewForConfig(config)
@@ -75,7 +75,7 @@ func NewClient() (*Client, error) {
 }
 
 func (c *Client) GetAllPodsInfo() ([]PodInfo, error) {
-	log.Println("Getting all pods from the cluster...")
+	slog.Info("Getting all pods from the cluster...")
 	pods, err := c.clientset.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("could not list pods: %w", err)
@@ -84,7 +84,7 @@ func (c *Client) GetAllPodsInfo() ([]PodInfo, error) {
 	var allPodsInfo []PodInfo
 	for _, pod := range pods.Items {
 		if pod.Status.PodIP == "" {
-			log.Printf("Skipping pod %s/%s: no IP address assigned (phase: %s)", pod.Namespace, pod.Name, pod.Status.Phase)
+			slog.Debug("skipping pod with no IP address", "namespace", pod.Namespace, "pod", pod.Name, "phase", pod.Status.Phase)
 			continue
 		}
 
@@ -108,7 +108,7 @@ func (c *Client) GetAllPodsInfo() ([]PodInfo, error) {
 		}
 		allPodsInfo = append(allPodsInfo, podInfo)
 	}
-	log.Printf("Found %d pods in the cluster (with IP addresses)", len(allPodsInfo))
+	slog.Info("pods found in cluster", "count", len(allPodsInfo))
 
 	totalIPs := 0
 	uniqueIPs := make(map[string]bool)
@@ -118,7 +118,7 @@ func (c *Client) GetAllPodsInfo() ([]PodInfo, error) {
 			uniqueIPs[ip] = true
 		}
 	}
-	log.Printf("IP discovery summary: %d total IPs across %d pods (%d unique IPs).", totalIPs, len(allPodsInfo), len(uniqueIPs))
+	slog.Info("IP discovery summary", "totalIPs", totalIPs, "pods", len(allPodsInfo), "uniqueIPs", len(uniqueIPs))
 
 	return allPodsInfo, nil
 }
@@ -128,7 +128,7 @@ func (c *Client) FilterPodsByComponent(pods []PodInfo, componentFilter string) [
 		return pods
 	}
 
-	log.Printf("Filtering pods by component name(s): %s", componentFilter)
+	slog.Info("filtering pods by component", "filter", componentFilter)
 	filterComponents := strings.Split(componentFilter, ",")
 	filterSet := make(map[string]struct{})
 	for _, comp := range filterComponents {
@@ -139,14 +139,14 @@ func (c *Client) FilterPodsByComponent(pods []PodInfo, componentFilter string) [
 	for _, pod := range pods {
 		component, err := c.GetOpenshiftComponentFromImage(pod.Image)
 		if err != nil {
-			log.Printf("Warning: could not get component for image %s: %v", pod.Image, err)
+			slog.Warn("could not get component for image", "image", pod.Image, "error", err)
 			continue
 		}
 		if _, ok := filterSet[component.Component]; ok {
 			filtered = append(filtered, pod)
 		}
 	}
-	log.Printf("Filtered pods: %d remaining out of %d", len(filtered), len(pods))
+	slog.Info("filtered pods by component", "remaining", len(filtered), "total", len(pods))
 	return filtered
 }
 
@@ -155,7 +155,7 @@ func FilterPodsByNamespace(pods []PodInfo, namespaceFilter string) []PodInfo {
 		return pods
 	}
 
-	log.Printf("Filtering pods by namespace(s): %s", namespaceFilter)
+	slog.Info("filtering pods by namespace", "filter", namespaceFilter)
 	filterNamespaces := strings.Split(namespaceFilter, ",")
 	filterSet := make(map[string]struct{})
 	for _, ns := range filterNamespaces {
@@ -168,6 +168,6 @@ func FilterPodsByNamespace(pods []PodInfo, namespaceFilter string) []PodInfo {
 			filtered = append(filtered, pod)
 		}
 	}
-	log.Printf("Filtered pods by namespace: %d remaining out of %d", len(filtered), len(pods))
+	slog.Info("filtered pods by namespace", "remaining", len(filtered), "total", len(pods))
 	return filtered
 }

--- a/internal/k8s/component.go
+++ b/internal/k8s/component.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -11,15 +11,15 @@ import (
 )
 
 func (c *Client) GetOpenshiftComponentFromImage(image string) (*OpenshiftComponent, error) {
-	log.Printf("Analyzing OpenShift image: %s", image)
+	slog.Debug("analyzing openshift image", "image", image)
 
 	component := c.parseOpenshiftComponentFromImageRef(image)
 	if component != nil {
-		log.Printf("Successfully parsed component info from image: %s -> %s", image, component.Component)
+		slog.Debug("parsed component info from image", "image", image, "component", component.Component)
 		return component, nil
 	}
 
-	log.Printf("Attempting to gather component info from cluster metadata for: %s", image)
+	slog.Debug("gathering component info from cluster metadata", "image", image)
 	return c.getComponentFromClusterMetadata(image)
 }
 
@@ -69,7 +69,7 @@ func (c *Client) parseOpenshiftComponentFromImageRef(image string) *OpenshiftCom
 }
 
 func (c *Client) getComponentFromClusterMetadata(image string) (*OpenshiftComponent, error) {
-	log.Printf("Searching cluster for pods using image: %s", image)
+	slog.Debug("searching cluster for pods using image", "image", image)
 
 	pods, err := c.clientset.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
 	if err != nil {

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"strconv"
 	"strings"
@@ -20,7 +20,7 @@ import (
 const procStateListen = "0A"
 
 func DiscoverPortsFromPodSpec(pod *v1.Pod) ([]int, error) {
-	log.Printf("Discovering ports for pod %s/%s from API server...", pod.Namespace, pod.Name)
+	slog.Debug("discovering ports from API server", "namespace", pod.Namespace, "pod", pod.Name)
 
 	var ports []int
 	for _, container := range pod.Spec.Containers {
@@ -40,9 +40,9 @@ func DiscoverPortsFromPodSpec(pod *v1.Pod) ([]int, error) {
 	}
 
 	if len(ports) == 0 {
-		log.Printf("Found 0 declared TCP ports for pod %s/%s.", pod.Namespace, pod.Name)
+		slog.Debug("no declared TCP ports found", "namespace", pod.Namespace, "pod", pod.Name)
 	} else {
-		log.Printf("Found %d declared TCP ports for pod %s/%s: %v", len(ports), pod.Namespace, pod.Name, ports)
+		slog.Debug("declared TCP ports found", "namespace", pod.Namespace, "pod", pod.Name, "count", len(ports), "ports", ports)
 	}
 
 	return ports, nil
@@ -119,7 +119,7 @@ func (c *Client) DiscoverPortsFromProc(pod PodInfo) ([]int, error) {
 	for port := range addrMap {
 		ports = append(ports, port)
 	}
-	log.Printf("Discovered %d listening ports from /proc/net/tcp in pod %s/%s: %v", len(ports), pod.Namespace, pod.Name, ports)
+	slog.Debug("discovered listening ports from /proc/net/tcp", "namespace", pod.Namespace, "pod", pod.Name, "count", len(ports), "ports", ports)
 	return ports, nil
 }
 

--- a/internal/k8s/process.go
+++ b/internal/k8s/process.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 	"strconv"
 	"strings"
 	"time"
@@ -24,7 +24,7 @@ func (c *Client) GetProcessMapForPod(pod PodInfo) (map[string]map[int]string, ma
 
 	command := []string{"/bin/sh", "-c", "lsof -i -sTCP:LISTEN -P -n -F cn"}
 	containerName := pod.Containers[0]
-	log.Printf("Executing lsof command in pod %s/%s, container %s: %v", pod.Namespace, pod.Name, containerName, command)
+	slog.Debug("executing lsof command", "namespace", pod.Namespace, "pod", pod.Name, "container", containerName, "command", command)
 
 	req := c.clientset.CoreV1().RESTClient().Post().
 		Resource("pods").
@@ -55,9 +55,9 @@ func (c *Client) GetProcessMapForPod(pod PodInfo) (map[string]map[int]string, ma
 		Stderr: &stderr,
 	})
 
-	log.Printf("lsof command for pod %s/%s finished.", pod.Namespace, pod.Name)
-	log.Printf("lsof stdout:\n%s", stdout.String())
-	log.Printf("lsof stderr:\n%s", stderr.String())
+	slog.Debug("lsof command finished", "namespace", pod.Namespace, "pod", pod.Name)
+	slog.Debug("lsof stdout", "output", stdout.String())
+	slog.Debug("lsof stderr", "output", stderr.String())
 
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
@@ -67,14 +67,14 @@ func (c *Client) GetProcessMapForPod(pod PodInfo) (map[string]map[int]string, ma
 	}
 
 	if stdout.Len() == 0 {
-		log.Printf("lsof command returned empty stdout for pod %s/%s.", pod.Namespace, pod.Name)
+		slog.Debug("lsof returned empty stdout", "namespace", pod.Namespace, "pod", pod.Name)
 	}
 
 	scanner := bufio.NewScanner(&stdout)
 	var currentProcess string
 	for scanner.Scan() {
 		line := scanner.Text()
-		log.Printf("Parsing lsof output line for pod %s/%s: %q", pod.Namespace, pod.Name, line)
+		slog.Debug("parsing lsof output line", "namespace", pod.Namespace, "pod", pod.Name, "line", line)
 		if len(line) > 1 {
 			fieldType := line[0]
 			fieldValue := line[1:]
@@ -102,13 +102,13 @@ func (c *Client) GetProcessMapForPod(pod PodInfo) (map[string]map[int]string, ma
 								ListenAddress: listenAddr,
 								ProcessName:   currentProcess,
 							}
-							log.Printf("Mapped pod %s/%s IP %s port %d to process %s (listen addr: %s)", pod.Namespace, pod.Name, ip, port, currentProcess, listenAddr)
+							slog.Debug("mapped port to process", "namespace", pod.Namespace, "pod", pod.Name, "ip", ip, "port", port, "process", currentProcess, "listenAddr", listenAddr)
 						}
 					} else {
-						log.Printf("Error converting port to integer for pod %s/%s: '%s' from line '%s'", pod.Namespace, pod.Name, portStr, line)
+						slog.Error("converting port to integer", "namespace", pod.Namespace, "pod", pod.Name, "portStr", portStr, "line", line)
 					}
 				} else {
-					log.Printf("Unexpected format for network address from lsof for pod %s/%s: '%s'", pod.Namespace, pod.Name, fieldValue)
+					slog.Warn("unexpected lsof network address format", "namespace", pod.Namespace, "pod", pod.Name, "address", fieldValue)
 				}
 			}
 		}
@@ -128,7 +128,7 @@ func (c *Client) GetAndCachePodProcesses(pod PodInfo) map[string]map[int]string 
 
 	processMap, listenInfoMap, err := c.GetProcessMapForPod(pod)
 	if err != nil {
-		log.Printf("Could not get process map for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+		slog.Warn("could not get process map for pod", "namespace", pod.Namespace, "pod", pod.Name, "error", err)
 		return nil
 	}
 

--- a/internal/k8s/tls.go
+++ b/internal/k8s/tls.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
-	"log"
+	"log/slog"
 
 	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +17,7 @@ var (
 )
 
 func (c *Client) GetTLSSecurityProfile() (*TLSSecurityProfile, error) {
-	log.Printf("Collecting TLS security profiles from OpenShift components...")
+	slog.Info("Collecting TLS security profiles from OpenShift components...")
 
 	profile := &TLSSecurityProfile{}
 
@@ -25,7 +25,7 @@ func (c *Client) GetTLSSecurityProfile() (*TLSSecurityProfile, error) {
 	// Kubelet inherit when no component-specific override is configured.
 	apiserver, err := c.configClient.ConfigV1().APIServers().Get(context.Background(), "cluster", metav1.GetOptions{})
 	if err != nil {
-		log.Printf("Warning: Could not get API Server custom resource: %v", err)
+		slog.Warn("could not get API Server custom resource", "error", err)
 		profile.TLSAdherence = configv1.TLSAdherencePolicyNoOpinion
 	} else {
 		profile.APIServer = extractAPIServerTLS(apiserver)
@@ -33,13 +33,13 @@ func (c *Client) GetTLSSecurityProfile() (*TLSSecurityProfile, error) {
 	}
 
 	if ingressTLS, err := c.getIngressControllerTLS(profile.APIServer); err != nil {
-		log.Printf("Warning: Could not get Ingress Controller TLS config: %v", err)
+		slog.Warn("could not get Ingress Controller TLS config", "error", err)
 	} else {
 		profile.IngressController = ingressTLS
 	}
 
 	if kubeletTLS, err := c.getKubeletTLS(profile.APIServer); err != nil {
-		log.Printf("Warning: Could not get Kubelet TLS config: %v", err)
+		slog.Warn("could not get Kubelet TLS config", "error", err)
 	} else {
 		profile.KubeletConfig = kubeletTLS
 	}

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -3,7 +3,7 @@ package output
 import (
 	"encoding/csv"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"slices"
 	"strconv"
@@ -24,7 +24,7 @@ var csvColumns = []string{
 }
 
 func WriteCSVOutput(results scanner.ScanResults, filename string) error {
-	log.Printf("Writing CSV output to: %s", filename)
+	slog.Info("writing CSV output", "path", filename)
 
 	file, err := os.Create(filename)
 	if err != nil {
@@ -191,11 +191,11 @@ func WriteCSVOutput(results scanner.ScanResults, filename string) error {
 
 func WriteScanErrorsCSV(results scanner.ScanResults, filename string) error {
 	if len(results.ScanErrors) == 0 {
-		log.Printf("No scan errors to write to CSV file")
+		slog.Info("No scan errors to write to CSV file")
 		return nil
 	}
 
-	log.Printf("Writing scan errors to: %s", filename)
+	slog.Info("writing scan errors", "path", filename)
 
 	file, err := os.Create(filename)
 	if err != nil {
@@ -227,7 +227,7 @@ func WriteScanErrorsCSV(results scanner.ScanResults, filename string) error {
 		}
 	}
 
-	log.Printf("Successfully wrote %d scan error rows to CSV file", len(results.ScanErrors))
+	slog.Info("scan error rows written to CSV", "count", len(results.ScanErrors))
 	return nil
 }
 

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -3,7 +3,7 @@ package output
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,7 +24,7 @@ func WriteJSONOutput(data interface{}, filename string) error {
 		return fmt.Errorf("failed to encode JSON: %v", err)
 	}
 
-	log.Printf("JSON output written to: %s", filename)
+	slog.Info("JSON output written", "path", filename)
 	return nil
 }
 
@@ -36,7 +36,7 @@ func WriteOutputFiles(results scanner.ScanResults, artifactDir, jsonFile, csvFil
 	if err := os.MkdirAll(artifactDir, 0755); err != nil {
 		return fmt.Errorf("could not create artifact directory %s: %v", artifactDir, err)
 	}
-	log.Printf("Artifacts will be saved to: %s", artifactDir)
+	slog.Info("artifacts directory created", "path", artifactDir)
 
 	if jsonFile != "" {
 		jsonPath := jsonFile
@@ -44,9 +44,9 @@ func WriteOutputFiles(results scanner.ScanResults, artifactDir, jsonFile, csvFil
 			jsonPath = filepath.Join(artifactDir, jsonFile)
 		}
 		if err := WriteJSONOutput(results, jsonPath); err != nil {
-			log.Printf("Error writing JSON output: %v", err)
+			slog.Error("writing JSON output", "error", err)
 		} else {
-			log.Printf("JSON results written to: %s", jsonPath)
+			slog.Info("JSON results written", "path", jsonPath)
 		}
 	}
 
@@ -56,17 +56,17 @@ func WriteOutputFiles(results scanner.ScanResults, artifactDir, jsonFile, csvFil
 			csvPath = filepath.Join(artifactDir, csvFile)
 		}
 		if err := WriteCSVOutput(results, csvPath); err != nil {
-			log.Printf("Error writing CSV output: %v", err)
+			slog.Error("writing CSV output", "error", err)
 		} else {
-			log.Printf("CSV results written to: %s", csvPath)
+			slog.Info("CSV results written", "path", csvPath)
 		}
 
 		if len(results.ScanErrors) > 0 {
 			errorFilename := strings.TrimSuffix(csvPath, filepath.Ext(csvPath)) + "_errors.csv"
 			if err := WriteScanErrorsCSV(results, errorFilename); err != nil {
-				log.Printf("Error writing scan errors CSV: %v", err)
+				slog.Error("writing scan errors CSV", "error", err)
 			} else {
-				log.Printf("Scan errors written to: %s", errorFilename)
+				slog.Info("scan errors written", "path", errorFilename)
 			}
 		}
 	}
@@ -77,9 +77,9 @@ func WriteOutputFiles(results scanner.ScanResults, artifactDir, jsonFile, csvFil
 			junitPath = filepath.Join(artifactDir, junitFile)
 		}
 		if err := WriteJUnitOutput(results, junitPath, pqcCheck); err != nil {
-			log.Printf("Error writing JUnit XML output: %v", err)
+			slog.Error("writing JUnit XML output", "error", err)
 		} else {
-			log.Printf("JUnit XML results written to: %s", junitPath)
+			slog.Info("JUnit XML results written", "path", junitPath)
 		}
 	}
 

--- a/internal/output/printer.go
+++ b/internal/output/printer.go
@@ -2,7 +2,7 @@ package output
 
 import (
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 
 	"github.com/openshift/tls-scanner/internal/scanner"
@@ -79,7 +79,7 @@ func PrintClusterResults(results scanner.ScanResults) {
 
 func PrintParsedResults(results scanner.ScanResults) {
 	if len(results.IPResults) == 0 {
-		log.Println("No hosts were scanned or host is down.")
+		slog.Warn("No hosts were scanned or host is down.")
 		return
 	}
 

--- a/internal/scanner/compliance.go
+++ b/internal/scanner/compliance.go
@@ -1,7 +1,7 @@
 package scanner
 
 import (
-	"log"
+	"log/slog"
 
 	"github.com/openshift/tls-scanner/internal/k8s"
 )
@@ -114,7 +114,7 @@ func checkCipherCompliance(gotCiphers []string, expectedCiphers []string) bool {
 			converted = cipher
 		}
 		if _, exists := expectedSet[converted]; !exists {
-			log.Printf("Warning: cipher %q (resolved as %q) not found in expected cipher set. cipher compliance will fail.", cipher, converted)
+			slog.Warn("cipher not found in expected cipher set, compliance will fail", "cipher", cipher, "resolved", converted)
 			return false
 		}
 	}

--- a/internal/scanner/policy.go
+++ b/internal/scanner/policy.go
@@ -3,7 +3,7 @@ package scanner
 import (
 	_ "embed"
 	"fmt"
-	"log"
+	"log/slog"
 	"regexp"
 
 	"gopkg.in/yaml.v3"
@@ -53,19 +53,18 @@ type ComponentPolicy struct {
 // Policy returns the org-wide component policy embedded in the binary.
 // It is the single source of truth for which TLS profile applies to each
 // component type. To change the policy, edit policy.yaml and submit for review.
-func Policy() *ComponentPolicy {
+func Policy() (*ComponentPolicy, error) {
 	var p ComponentPolicy
 	if err := yaml.Unmarshal(embeddedPolicyYAML, &p); err != nil {
-		// policy.yaml is checked into source; a parse failure is a programming error.
-		panic(fmt.Sprintf("failed to parse embedded policy: %v", err))
+		return nil, fmt.Errorf("failed to parse embedded policy: %w", err)
 	}
 	for i := range p.Rules {
 		if err := p.Rules[i].compile(); err != nil {
-			panic(fmt.Sprintf("policy rule %d: %v", i, err))
+			return nil, fmt.Errorf("policy rule %d: %w", i, err)
 		}
 	}
 	p.warnShadowedRules()
-	return &p
+	return &p, nil
 }
 
 // warnShadowedRules logs a warning for each rule that can never be reached
@@ -74,11 +73,9 @@ func (p *ComponentPolicy) warnShadowedRules() {
 	for i := 0; i < len(p.Rules); i++ {
 		for j := i + 1; j < len(p.Rules); j++ {
 			if p.Rules[i].shadows(&p.Rules[j]) {
-				log.Printf("Warning: policy rule %d (%s) shadows rule %d (%s) — rule %d will never be reached. "+
-					"Check policy.yaml and move more-specific rules before broader ones.",
-					i, p.Rules[i].description(),
-					j, p.Rules[j].description(),
-					j)
+				slog.Warn("policy rule shadows another rule, check policy.yaml and move more-specific rules before broader ones",
+					"shadowingRule", i, "shadowingDesc", p.Rules[i].description(),
+					"shadowedRule", j, "shadowedDesc", p.Rules[j].description())
 			}
 		}
 	}

--- a/internal/scanner/policy_test.go
+++ b/internal/scanner/policy_test.go
@@ -103,8 +103,17 @@ func TestPolicyRuleShadowing(t *testing.T) {
 	}
 }
 
+func testPolicy(t *testing.T) *ComponentPolicy {
+	t.Helper()
+	p, err := Policy()
+	if err != nil {
+		t.Fatalf("Policy() error: %v", err)
+	}
+	return p
+}
+
 func TestPolicy(t *testing.T) {
-	p := Policy()
+	p := testPolicy(t)
 	if p == nil {
 		t.Fatal("Policy() returned nil")
 	}
@@ -250,7 +259,7 @@ func TestPolicyResolve(t *testing.T) {
 }
 
 func TestPolicyBehaviour(t *testing.T) {
-	p := Policy()
+	p := testPolicy(t)
 
 	tests := []struct {
 		name      string

--- a/internal/scanner/pqc.go
+++ b/internal/scanner/pqc.go
@@ -1,7 +1,7 @@
 package scanner
 
 import (
-	"log"
+	"log/slog"
 	"slices"
 )
 
@@ -90,12 +90,12 @@ func HasPQCComplianceFailures(results ScanResults, skip PortFilter) bool {
 			}
 
 			if !portResult.TLS13Supported {
-				log.Printf("PQC compliance failure: %s:%d - TLS 1.3 not supported", ipResult.IP, portResult.Port)
+				slog.Warn("PQC compliance failure: TLS 1.3 not supported", "ip", ipResult.IP, "port", portResult.Port)
 				return true
 			}
 
 			if !portResult.MLKEMSupported {
-				log.Printf("PQC compliance failure: %s:%d - ML-KEM not supported", ipResult.IP, portResult.Port)
+				slog.Warn("PQC compliance failure: ML-KEM not supported", "ip", ipResult.IP, "port", portResult.Port)
 				return true
 			}
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net"
 	"os"
 	"os/exec"
@@ -50,7 +50,7 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 	var tlsConfig *k8s.TLSSecurityProfile
 	if client != nil {
 		if config, err := client.GetTLSSecurityProfile(); err != nil {
-			log.Printf("Warning: Could not collect TLS security profiles: %v", err)
+			slog.Warn("could not collect TLS security profiles", "error", err)
 		} else {
 			tlsConfig = config
 		}
@@ -68,7 +68,7 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 		go func(workerID int) {
 			defer discoveryWG.Done()
 			for pod := range discoveryChan {
-				log.Printf("DISCOVERY %d: Processing pod %s/%s", workerID, pod.Namespace, pod.Name)
+				slog.Debug("discovery processing pod", "worker", workerID, "namespace", pod.Namespace, "pod", pod.Name)
 				progress.PodDiscovered()
 
 				var component *k8s.OpenshiftComponent
@@ -83,7 +83,7 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 				var err error
 				procPorts, err = client.DiscoverPortsFromProc(pod)
 				if err != nil {
-					log.Printf("Warning: /proc port discovery failed for %s/%s: %v", pod.Namespace, pod.Name, err)
+					slog.Warn("/proc port discovery failed", "namespace", pod.Namespace, "pod", pod.Name, "error", err)
 				} else {
 					procAvailable = true
 				}
@@ -113,8 +113,11 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 			// Identify plaintext probe ports up front so we can skip them below.
 			probePorts := k8s.GetPlaintextProbePorts(pod.Pod)
 
-			log.Printf("DISCOVERY %d: %s/%s hostNet=%v spec=%v proc=%v open=%v probePorts=%v (%d ports)",
-				workerID, pod.Namespace, pod.Name, pod.Pod.Spec.HostNetwork, specPorts, procPorts, openPorts, probePorts, len(openPorts))
+			slog.Debug("discovery result",
+				"worker", workerID, "namespace", pod.Namespace, "pod", pod.Name,
+				"hostNetwork", pod.Pod.Spec.HostNetwork, "specPorts", specPorts,
+				"procPorts", procPorts, "openPorts", openPorts,
+				"probePorts", probePorts, "portCount", len(openPorts))
 
 				for _, ip := range pod.IPs {
 					if len(openPorts) == 0 {
@@ -137,7 +140,7 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 					for _, port := range openPorts {
 						if client != nil {
 							if isLocalhost, listenAddr := client.IsLocalhostOnly(ip, port); isLocalhost {
-								log.Printf("Port %d on %s is bound to localhost only (%s), skipping", port, ip, listenAddr)
+								slog.Debug("port bound to localhost only, skipping", "port", port, "ip", ip, "listenAddr", listenAddr)
 								pr := PortResult{
 									Port:          port,
 									Protocol:      "tcp",
@@ -161,7 +164,7 @@ func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Cli
 						}
 
 						if probePorts[port] {
-							log.Printf("Port %d on %s is a plaintext health probe endpoint, skipping TLS scan", port, ip)
+							slog.Debug("plaintext health probe endpoint, skipping TLS scan", "port", port, "ip", ip)
 							pr := PortResult{
 								Port:     port,
 								Protocol: "tcp",
@@ -280,23 +283,23 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 
 	targetsFile, err := writeTargetsFile(targets)
 	if err != nil {
-		log.Printf("Failed to create targets file: %v", err)
+		slog.Error("failed to create targets file", "error", err)
 		return nil
 	}
 	defer os.Remove(targetsFile)
 
 	outputFile, err := os.CreateTemp("", "testssl-batch-*.json")
 	if err != nil {
-		log.Printf("Failed to create output file: %v", err)
+		slog.Error("failed to create output file", "error", err)
 		return nil
 	}
 	outputFileName := outputFile.Name()
 	outputFile.Close()
 	defer os.Remove(outputFileName)
 
-	log.Printf("Running testssl.sh --file batch scan on %d targets (MAX_PARALLEL=%d)", len(targets), concurrentScans)
+	slog.Info("running testssl.sh batch scan", "targets", len(targets), "maxParallel", concurrentScans)
 	timeout := time.Duration(len(targets)*90+120) * time.Second
-	log.Printf("Batch timeout: %v", timeout)
+	slog.Debug("batch timeout set", "timeout", timeout)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
@@ -318,21 +321,21 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 
 	if cmdErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			log.Printf("ERROR: testssl.sh batch TIMED OUT after %v (%d targets). Partial results may be available.", timeout, len(targets))
+			slog.Error("testssl.sh batch timed out, partial results may be available", "timeout", timeout, "targets", len(targets))
 		} else {
-			log.Printf("testssl.sh batch exited non-zero: %v", cmdErr)
+			slog.Warn("testssl.sh batch exited non-zero", "error", cmdErr)
 		}
 	}
 
 	jsonData, readErr := os.ReadFile(outputFileName)
 	if readErr != nil || len(jsonData) == 0 {
-		log.Printf("testssl.sh batch produced no output: %v", readErr)
+		slog.Error("testssl.sh batch produced no output", "error", readErr)
 		return nil
 	}
 
 	grouped, groupErr := GroupTestSSLOutputByIPPort(jsonData)
 	if groupErr != nil {
-		log.Printf("Error grouping testssl.sh output: %v", groupErr)
+		slog.Error("grouping testssl.sh output", "error", groupErr)
 		return nil
 	}
 
@@ -341,7 +344,7 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 	for key, findings := range grouped {
 		job, ok := jobIndex[key]
 		if !ok {
-			log.Printf("Warning: testssl returned results for unknown target %s", key)
+			slog.Warn("testssl returned results for unknown target", "target", key)
 			continue
 		}
 		delete(jobIndex, key)
@@ -399,7 +402,7 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 	}
 
 	for key, job := range jobIndex {
-		log.Printf("Warning: no testssl results for %s", key)
+		slog.Warn("no testssl results for target", "target", key)
 		results = append(results, portScanResult{
 			ip: job.IP, pod: job.Pod, component: job.Component,
 			result: PortResult{

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -41,7 +41,7 @@ func TestScanWithMockTestSSL(t *testing.T) {
 		{IP: "10.0.0.1", Port: 443},
 		{IP: "10.0.0.2", Port: 8443},
 	}
-	results := Scan(jobs, 2, nil, nil, Policy())
+	results := Scan(jobs, 2, nil, nil, testPolicy(t))
 
 	if results.ScannedIPs != 2 {
 		t.Fatalf("expected 2 scanned IPs, got %d", results.ScannedIPs)
@@ -65,7 +65,7 @@ func TestScanPQCEnrichment(t *testing.T) {
 	testutil.InstallMockTestSSL(t)
 
 	jobs := []ScanJob{{IP: "10.0.0.1", Port: 443}}
-	results := Scan(jobs, 1, nil, nil, Policy())
+	results := Scan(jobs, 1, nil, nil, testPolicy(t))
 
 	pr := results.IPResults[0].PortResults[0]
 
@@ -98,7 +98,7 @@ func TestPerformClusterScanWithMockPods(t *testing.T) {
 		makePod("no-ports", "openshift-console", "10.128.0.30"),
 	}
 
-	results := PerformClusterScan(pods, 2, nil, Policy())
+	results := PerformClusterScan(pods, 2, nil, testPolicy(t))
 
 	if results.ScannedIPs != 3 {
 		t.Errorf("expected 3 scanned IPs (including no-ports), got %d", results.ScannedIPs)

--- a/internal/scanner/testssl.go
+++ b/internal/scanner/testssl.go
@@ -2,7 +2,7 @@ package scanner
 
 import (
 	"encoding/json"
-	"log"
+	"log/slog"
 	"os"
 	"os/exec"
 	"regexp"
@@ -21,7 +21,7 @@ func ParseTestSSLOutput(jsonData []byte, host, port string) ScanRun {
 	var rawData []map[string]interface{}
 
 	if err := json.Unmarshal(jsonData, &rawData); err != nil {
-		log.Printf("Error parsing testssl.sh JSON output: %v", err)
+		slog.Error("parsing testssl.sh JSON output", "error", err)
 		return ScanRun{Hosts: []Host{{
 			Ports: []Port{{
 				PortID:   port,
@@ -222,7 +222,7 @@ func mapSeverityToStrength(severity string) string {
 func ExtractKeyExchangeFromTestSSL(jsonData []byte) *KeyExchangeInfo {
 	var rawData []map[string]interface{}
 	if err := json.Unmarshal(jsonData, &rawData); err != nil {
-		log.Printf("Error parsing testssl.sh JSON for key exchange: %v", err)
+		slog.Error("parsing testssl.sh JSON for key exchange", "error", err)
 		return nil
 	}
 
@@ -339,7 +339,7 @@ func GroupTestSSLOutputByPort(jsonData []byte) (map[string][]map[string]interfac
 func ParseTestSSLOutputFromFile(filename, host, port string) ScanRun {
 	data, err := os.ReadFile(filename)
 	if err != nil {
-		log.Printf("Error reading testssl output file %s: %v", filename, err)
+		slog.Error("reading testssl output file", "path", filename, "error", err)
 		return ScanRun{Hosts: []Host{{
 			Ports: []Port{{
 				PortID:   port,
@@ -382,7 +382,7 @@ func GroupTestSSLOutputByIPPort(jsonData []byte) (map[string][]map[string]interf
 func ExtractCiphersFromTestSSL(jsonData []byte) []string {
 	var rawData []map[string]interface{}
 	if err := json.Unmarshal(jsonData, &rawData); err != nil {
-		log.Printf("Error parsing testssl.sh JSON for ciphers: %v", err)
+		slog.Error("parsing testssl.sh JSON for ciphers", "error", err)
 		return nil
 	}
 
@@ -408,7 +408,7 @@ func ExtractCiphersFromTestSSL(jsonData []byte) []string {
 		// find the cipher by retrieving the third item
 		matches := r.FindStringSubmatch(cipher)
 		if len(matches) < 2 {
-			log.Printf("Expected a ciper in %q, did not find any", cipher)
+			slog.Warn("expected a cipher in finding, did not find any", "finding", cipher)
 			continue
 		}
 		cipher = matches[1]

--- a/internal/scanner/testssl_integration_test.go
+++ b/internal/scanner/testssl_integration_test.go
@@ -33,7 +33,7 @@ func TestIntegrationSingleTarget(t *testing.T) {
 	jobs := []ScanJob{{IP: tgt.ip, Port: tgt.port}}
 
 	start := time.Now()
-	results := batchScan(jobs, 1, nil, nil, Policy())
+	results := batchScan(jobs, 1, nil, nil, testPolicy(t))
 	elapsed := time.Since(start)
 
 	t.Logf("Single target %s (%s:%d): %v", tgt.desc, tgt.ip, tgt.port, elapsed)
@@ -73,7 +73,7 @@ func TestIntegrationBatchTargets(t *testing.T) {
 	}
 
 	start := time.Now()
-	results := batchScan(jobs, 4, nil, nil, Policy())
+	results := batchScan(jobs, 4, nil, nil, testPolicy(t))
 	elapsed := time.Since(start)
 
 	t.Logf("Batch %d targets (MAX_PARALLEL=4): %v (%.1fs/target)",
@@ -102,12 +102,12 @@ func TestIntegrationParallelScaling(t *testing.T) {
 
 	t.Log("--- Sequential run (MAX_PARALLEL=1) ---")
 	start := time.Now()
-	seqResults := batchScan(jobs, 1, nil, nil, Policy())
+	seqResults := batchScan(jobs, 1, nil, nil, testPolicy(t))
 	sequential := time.Since(start)
 
 	t.Log("--- Parallel run (MAX_PARALLEL=", len(jobs), ") ---")
 	start = time.Now()
-	parResults := batchScan(jobs, len(jobs), nil, nil, Policy())
+	parResults := batchScan(jobs, len(jobs), nil, nil, testPolicy(t))
 	parallel := time.Since(start)
 
 	speedup := sequential.Seconds() / parallel.Seconds()


### PR DESCRIPTION
## Summary

- Migrates all `log.Printf` calls to Go's stdlib `log/slog` with structured key-value pairs
- Adds `--log-level` flag accepting `debug`, `info`, `warn`, `error` (default: `info`)
- Debug level enables verbose output including per-pod discovery detail, lsof output, and component analysis
- Warn level suppresses informational messages
- All log messages use idiomatic slog structured args for efficient filtering and machine-parseable output
- Replaces `panic` with error return in `Policy()` for graceful handling of policy parse failures (supersedes #52)
- No new dependencies — `log/slog` is Go stdlib

Jira: https://redhat.atlassian.net/browse/CNF-23702