### PR TITLE
CNF-23796: Improve test coverage from 49.5% to 62.5%

### DIFF
--- a/internal/k8s/component_test.go
+++ b/internal/k8s/component_test.go
@@ -1,0 +1,244 @@
+package k8s
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExtractComponentNameFromImage(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	tests := []struct {
+		image string
+		want  string
+	}{
+		{"quay.io/openshift/router:v4.18", "router"},
+		{"quay.io/openshift/router@sha256:abc123", "router"},
+		{"quay.io/openshift/router", "router"},
+		{"registry.redhat.com/openshift4/ose-cli:latest", "ose-cli"},
+		{"nginx", "nginx"},
+		{"docker.io/library/nginx:1.25", "nginx"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.image, func(t *testing.T) {
+			t.Parallel()
+			got := c.extractComponentNameFromImage(tt.image)
+			if got != tt.want {
+				t.Errorf("extractComponentNameFromImage(%q) = %q, want %q", tt.image, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractRegistryFromImage(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	tests := []struct {
+		image string
+		want  string
+	}{
+		{"quay.io/openshift/router:v4.18", "quay.io"},
+		{"registry.redhat.com/openshift4/ose-cli", "registry.redhat.com"},
+		{"image-registry.openshift-image-registry.svc:5000/ns/img", "internal-registry"},
+		{"docker.io/library/nginx", "docker.io"},
+		{"gcr.io/project/image", "gcr.io"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.image, func(t *testing.T) {
+			t.Parallel()
+			got := c.extractRegistryFromImage(tt.image)
+			if got != tt.want {
+				t.Errorf("extractRegistryFromImage(%q) = %q, want %q", tt.image, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseOpenshiftComponentFromImageRef(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	tests := []struct {
+		name      string
+		image     string
+		wantNil   bool
+		wantComp  string
+		wantMaint string
+	}{
+		{
+			name:      "oauth",
+			image:     "quay.io/openshift-release-dev/ocp-v4.0-art-dev:oauth-openshift",
+			wantComp:  "oauth-openshift",
+			wantMaint: "openshift",
+		},
+		{
+			name:      "apiserver",
+			image:     "quay.io/openshift-release-dev/ocp-v4.0-art-dev:apiserver",
+			wantComp:  "openshift-apiserver",
+			wantMaint: "openshift",
+		},
+		{
+			name:      "controller-manager",
+			image:     "quay.io/openshift-release-dev/ocp-v4.0-art-dev:controller-manager",
+			wantComp:  "openshift-controller-manager",
+			wantMaint: "openshift",
+		},
+		{
+			name:      "generic openshift-release-dev",
+			image:     "quay.io/openshift-release-dev/ocp-v4.0-art-dev:etcd",
+			wantComp:  "openshift-component",
+			wantMaint: "openshift",
+		},
+		{
+			name:      "internal registry",
+			image:     "image-registry.openshift-image-registry.svc:5000/openshift/origin-router:latest",
+			wantComp:  "origin-router:latest",
+			wantMaint: "user",
+		},
+		{
+			name:      "quay.io non-release-dev",
+			image:     "quay.io/coreos/etcd:v3.5.0",
+			wantComp:  "etcd",
+			wantMaint: "redhat",
+		},
+		{
+			name:      "registry.redhat.com",
+			image:     "registry.redhat.com/openshift4/ose-cli:v4.18",
+			wantComp:  "ose-cli",
+			wantMaint: "redhat",
+		},
+		{
+			name:    "unrecognized registry",
+			image:   "docker.io/library/nginx:1.25",
+			wantNil: true,
+		},
+		{
+			name:    "no registry prefix",
+			image:   "nginx:latest",
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := c.parseOpenshiftComponentFromImageRef(tt.image)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("expected nil for %q, got %+v", tt.image, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected non-nil for %q", tt.image)
+			}
+			if got.Component != tt.wantComp {
+				t.Errorf("Component = %q, want %q", got.Component, tt.wantComp)
+			}
+			if got.MaintainerComponent != tt.wantMaint {
+				t.Errorf("MaintainerComponent = %q, want %q", got.MaintainerComponent, tt.wantMaint)
+			}
+		})
+	}
+}
+
+func TestExtractComponentFromPod(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	tests := []struct {
+		name      string
+		labels    map[string]string
+		container v1.Container
+		want      string
+	}{
+		{
+			name:      "app label",
+			labels:    map[string]string{"app": "my-app"},
+			container: v1.Container{Name: "ctr", Image: "quay.io/x/y:z"},
+			want:      "my-app",
+		},
+		{
+			name:      "component label",
+			labels:    map[string]string{"component": "my-component"},
+			container: v1.Container{Name: "ctr", Image: "quay.io/x/y:z"},
+			want:      "my-component",
+		},
+		{
+			name:      "app.kubernetes.io/name label",
+			labels:    map[string]string{"app.kubernetes.io/name": "k8s-app"},
+			container: v1.Container{Name: "ctr", Image: "quay.io/x/y:z"},
+			want:      "k8s-app",
+		},
+		{
+			name:      "app label takes precedence over component",
+			labels:    map[string]string{"app": "winner", "component": "loser"},
+			container: v1.Container{Name: "ctr"},
+			want:      "winner",
+		},
+		{
+			name:      "falls back to container name",
+			labels:    map[string]string{},
+			container: v1.Container{Name: "my-container", Image: "nginx"},
+			want:      "my-container",
+		},
+		{
+			name:      "falls back to image name",
+			labels:    map[string]string{},
+			container: v1.Container{Name: "", Image: "quay.io/org/my-image:v1"},
+			want:      "my-image",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pod := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Labels: tt.labels},
+			}
+			got := c.extractComponentFromPod(pod, tt.container)
+			if got != tt.want {
+				t.Errorf("extractComponentFromPod() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractMaintainerFromPod(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	tests := []struct {
+		name      string
+		namespace string
+		labels    map[string]string
+		want      string
+	}{
+		{"openshift namespace", "openshift-apiserver", nil, "openshift"},
+		{"kube namespace", "kube-system", nil, "kubernetes"},
+		{"maintainer label", "default", map[string]string{"maintainer": "team-x"}, "team-x"},
+		{"unknown", "default", nil, "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pod := v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: tt.namespace,
+					Labels:    tt.labels,
+				},
+			}
+			got := c.extractMaintainerFromPod(pod)
+			if got != tt.want {
+				t.Errorf("extractMaintainerFromPod() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/k8s/discovery_test.go
+++ b/internal/k8s/discovery_test.go
@@ -178,6 +178,96 @@ func TestParseProcNetTCP(t *testing.T) {
 		})
 	}
 }
+func TestDiscoverPortsFromPodSpec(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		pod  *v1.Pod
+		want []int
+	}{
+		{
+			name: "TCP ports from containers",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{Containers: []v1.Container{{
+					Name: "c",
+					Ports: []v1.ContainerPort{
+						{ContainerPort: 443, Protocol: v1.ProtocolTCP},
+						{ContainerPort: 8443, Protocol: v1.ProtocolTCP},
+					},
+				}}},
+			},
+			want: []int{443, 8443},
+		},
+		{
+			name: "UDP ports excluded",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{Containers: []v1.Container{{
+					Name: "c",
+					Ports: []v1.ContainerPort{
+						{ContainerPort: 443, Protocol: v1.ProtocolTCP},
+						{ContainerPort: 53, Protocol: v1.ProtocolUDP},
+					},
+				}}},
+			},
+			want: []int{443},
+		},
+		{
+			name: "init container ports included",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{{
+						Name:  "main",
+						Ports: []v1.ContainerPort{{ContainerPort: 443, Protocol: v1.ProtocolTCP}},
+					}},
+					InitContainers: []v1.Container{{
+						Name:  "init",
+						Ports: []v1.ContainerPort{{ContainerPort: 9090, Protocol: v1.ProtocolTCP}},
+					}},
+				},
+			},
+			want: []int{443, 9090},
+		},
+		{
+			name: "no ports",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "c"}}},
+			},
+			want: nil,
+		},
+		{
+			name: "multiple containers",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "c1", Ports: []v1.ContainerPort{{ContainerPort: 443, Protocol: v1.ProtocolTCP}}},
+					{Name: "c2", Ports: []v1.ContainerPort{{ContainerPort: 8443, Protocol: v1.ProtocolTCP}}},
+				}},
+			},
+			want: []int{443, 8443},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := DiscoverPortsFromPodSpec(tt.pod)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			sort.Ints(got)
+			sort.Ints(tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DiscoverPortsFromPodSpec() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func intPort(n int) intstr.IntOrString     { return intstr.FromInt(n) }
 func namedPort(s string) intstr.IntOrString { return intstr.FromString(s) }
 

--- a/internal/k8s/process_test.go
+++ b/internal/k8s/process_test.go
@@ -103,6 +103,57 @@ func TestIsLocalhostOnly_ipv6Localhost(t *testing.T) {
 	}
 }
 
+func TestGetListenInfo(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	c.listenInfoMap["10.0.0.1"] = map[int]ListenInfo{
+		443: {Port: 443, ListenAddress: "0.0.0.0", ProcessName: "nginx"},
+	}
+
+	info, ok := c.GetListenInfo("10.0.0.1", 443)
+	if !ok {
+		t.Fatal("expected ok=true for known port")
+	}
+	if info.ListenAddress != "0.0.0.0" {
+		t.Errorf("ListenAddress = %q, want %q", info.ListenAddress, "0.0.0.0")
+	}
+
+	_, ok = c.GetListenInfo("10.0.0.1", 9999)
+	if ok {
+		t.Error("expected ok=false for unknown port")
+	}
+
+	_, ok = c.GetListenInfo("10.0.0.2", 443)
+	if ok {
+		t.Error("expected ok=false for unknown IP")
+	}
+}
+
+func TestGetProcessName(t *testing.T) {
+	t.Parallel()
+
+	c := newTestClient()
+	c.processNameMap["10.0.0.1"] = map[int]string{
+		443: "nginx",
+	}
+
+	name, ok := c.GetProcessName("10.0.0.1", 443)
+	if !ok || name != "nginx" {
+		t.Errorf("GetProcessName() = (%q, %v), want (%q, true)", name, ok, "nginx")
+	}
+
+	_, ok = c.GetProcessName("10.0.0.1", 9999)
+	if ok {
+		t.Error("expected ok=false for unknown port")
+	}
+
+	_, ok = c.GetProcessName("10.0.0.2", 443)
+	if ok {
+		t.Error("expected ok=false for unknown IP")
+	}
+}
+
 func TestIsLocalhostAddr(t *testing.T) {
 	tests := []struct {
 		addr string

--- a/internal/k8s/tls_test.go
+++ b/internal/k8s/tls_test.go
@@ -1,0 +1,98 @@
+package k8s
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestExtractAPIServerTLSNilProfile(t *testing.T) {
+	t.Parallel()
+
+	apiserver := &configv1.APIServer{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec:       configv1.APIServerSpec{},
+	}
+
+	got := extractAPIServerTLS(apiserver)
+	if got.Type != "Default" {
+		t.Errorf("Type = %q, want %q", got.Type, "Default")
+	}
+	if got.MinTLSVersion == "" {
+		t.Error("MinTLSVersion should not be empty for default profile")
+	}
+	if len(got.Ciphers) == 0 {
+		t.Error("Ciphers should not be empty for default profile")
+	}
+}
+
+func TestExtractAPIServerTLSCustomProfile(t *testing.T) {
+	t.Parallel()
+
+	apiserver := &configv1.APIServer{
+		Spec: configv1.APIServerSpec{
+			TLSSecurityProfile: &configv1.TLSSecurityProfile{
+				Type: configv1.TLSProfileCustomType,
+				Custom: &configv1.CustomTLSProfile{
+					TLSProfileSpec: configv1.TLSProfileSpec{
+						Ciphers:       []string{"ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-RSA-CHACHA20-POLY1305"},
+						MinTLSVersion: configv1.VersionTLS12,
+					},
+				},
+			},
+		},
+	}
+
+	got := extractAPIServerTLS(apiserver)
+	if got.Type != "Custom" {
+		t.Errorf("Type = %q, want %q", got.Type, "Custom")
+	}
+	if got.MinTLSVersion != "VersionTLS12" {
+		t.Errorf("MinTLSVersion = %q, want %q", got.MinTLSVersion, "VersionTLS12")
+	}
+	if len(got.Ciphers) != 2 {
+		t.Fatalf("expected 2 ciphers, got %d", len(got.Ciphers))
+	}
+}
+
+func TestExtractAPIServerTLSPredefinedProfiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		profileType configv1.TLSProfileType
+		wantType   string
+	}{
+		{"Old", configv1.TLSProfileOldType, "Old"},
+		{"Intermediate", configv1.TLSProfileIntermediateType, "Intermediate"},
+		{"Modern", configv1.TLSProfileModernType, "Modern"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			apiserver := &configv1.APIServer{
+				Spec: configv1.APIServerSpec{
+					TLSSecurityProfile: &configv1.TLSSecurityProfile{
+						Type: tt.profileType,
+					},
+				},
+			}
+
+			got := extractAPIServerTLS(apiserver)
+			if got.Type != tt.wantType {
+				t.Errorf("Type = %q, want %q", got.Type, tt.wantType)
+			}
+
+			expected := configv1.TLSProfiles[tt.profileType]
+			if got.MinTLSVersion != string(expected.MinTLSVersion) {
+				t.Errorf("MinTLSVersion = %q, want %q", got.MinTLSVersion, expected.MinTLSVersion)
+			}
+			if len(got.Ciphers) != len(expected.Ciphers) {
+				t.Errorf("Ciphers count = %d, want %d", len(got.Ciphers), len(expected.Ciphers))
+			}
+		})
+	}
+}

--- a/internal/output/json_test.go
+++ b/internal/output/json_test.go
@@ -1,0 +1,130 @@
+package output
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openshift/tls-scanner/internal/k8s"
+	"github.com/openshift/tls-scanner/internal/scanner"
+)
+
+func testScanResults() scanner.ScanResults {
+	return scanner.ScanResults{
+		Timestamp:  "2026-05-13T12:00:00Z",
+		TotalIPs:   1,
+		ScannedIPs: 1,
+		IPResults: []scanner.IPResult{{
+			IP:     "10.0.0.1",
+			Status: "scanned",
+			Pod:    &k8s.PodInfo{Name: "pod-a", Namespace: "ns-a"},
+			PortResults: []scanner.PortResult{{
+				Port:     443,
+				Protocol: "tcp",
+				Service:  "https",
+				Status:   scanner.StatusOK,
+			}},
+		}},
+	}
+}
+
+func TestWriteJSONOutput(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "results.json")
+	results := testScanResults()
+
+	if err := WriteJSONOutput(results, path); err != nil {
+		t.Fatalf("WriteJSONOutput returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading output: %v", err)
+	}
+
+	var got scanner.ScanResults
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if got.Timestamp != "2026-05-13T12:00:00Z" {
+		t.Errorf("Timestamp = %q, want %q", got.Timestamp, "2026-05-13T12:00:00Z")
+	}
+	if len(got.IPResults) != 1 {
+		t.Fatalf("expected 1 IPResult, got %d", len(got.IPResults))
+	}
+	if got.IPResults[0].IP != "10.0.0.1" {
+		t.Errorf("IP = %q, want %q", got.IPResults[0].IP, "10.0.0.1")
+	}
+}
+
+func TestWriteOutputFilesNoop(t *testing.T) {
+	t.Parallel()
+
+	results := testScanResults()
+	if err := WriteOutputFiles(results, t.TempDir(), "", "", "", false); err != nil {
+		t.Fatalf("expected nil for empty filenames, got: %v", err)
+	}
+}
+
+func TestWriteOutputFilesJSON(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	results := testScanResults()
+	if err := WriteOutputFiles(results, dir, "out.json", "", "", false); err != nil {
+		t.Fatalf("WriteOutputFiles returned error: %v", err)
+	}
+
+	path := filepath.Join(dir, "out.json")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected JSON file at %s: %v", path, err)
+	}
+}
+
+func TestWriteOutputFilesAbsolutePath(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	artifactDir := filepath.Join(dir, "artifacts")
+	absPath := filepath.Join(dir, "absolute.json")
+	results := testScanResults()
+	if err := WriteOutputFiles(results, artifactDir, absPath, "", "", false); err != nil {
+		t.Fatalf("WriteOutputFiles returned error: %v", err)
+	}
+
+	if _, err := os.Stat(absPath); err != nil {
+		t.Errorf("expected JSON file at absolute path %s: %v", absPath, err)
+	}
+}
+
+func TestWriteOutputFilesCSV(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	results := testScanResults()
+	if err := WriteOutputFiles(results, dir, "", "out.csv", "", false); err != nil {
+		t.Fatalf("WriteOutputFiles returned error: %v", err)
+	}
+
+	path := filepath.Join(dir, "out.csv")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected CSV file at %s: %v", path, err)
+	}
+}
+
+func TestWriteOutputFilesJUnit(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	results := testScanResults()
+	if err := WriteOutputFiles(results, dir, "", "", "out.xml", false); err != nil {
+		t.Fatalf("WriteOutputFiles returned error: %v", err)
+	}
+
+	path := filepath.Join(dir, "out.xml")
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected JUnit file at %s: %v", path, err)
+	}
+}

--- a/internal/output/junit_test.go
+++ b/internal/output/junit_test.go
@@ -1,0 +1,230 @@
+package output
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/tls-scanner/internal/k8s"
+	"github.com/openshift/tls-scanner/internal/scanner"
+)
+
+func readJUnitSuite(t *testing.T, path string) JUnitTestSuite {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading JUnit output: %v", err)
+	}
+	var suite JUnitTestSuite
+	if err := xml.Unmarshal(data, &suite); err != nil {
+		t.Fatalf("invalid XML: %v", err)
+	}
+	return suite
+}
+
+func TestWriteJUnitOutputBasic(t *testing.T) {
+	t.Parallel()
+
+	results := testScanResults()
+	path := filepath.Join(t.TempDir(), "results.xml")
+
+	if err := WriteJUnitOutput(results, path, false); err != nil {
+		t.Fatalf("WriteJUnitOutput returned error: %v", err)
+	}
+
+	suite := readJUnitSuite(t, path)
+	if suite.Name != "TLSSecurityScan" {
+		t.Errorf("Name = %q, want %q", suite.Name, "TLSSecurityScan")
+	}
+	if suite.Tests != 1 {
+		t.Errorf("Tests = %d, want 1", suite.Tests)
+	}
+	if suite.Failures != 0 {
+		t.Errorf("Failures = %d, want 0", suite.Failures)
+	}
+}
+
+func TestWriteJUnitOutputPQCFailures(t *testing.T) {
+	t.Parallel()
+
+	results := scanner.ScanResults{
+		IPResults: []scanner.IPResult{{
+			IP:     "10.0.0.1",
+			Status: "scanned",
+			Pod:    &k8s.PodInfo{Name: "pod-a", Namespace: "ns-a"},
+			PortResults: []scanner.PortResult{{
+				Port:           443,
+				Protocol:       "tcp",
+				Status:         scanner.StatusOK,
+				TLS13Supported: false,
+				MLKEMSupported: false,
+			}},
+		}},
+	}
+
+	path := filepath.Join(t.TempDir(), "pqc.xml")
+	if err := WriteJUnitOutput(results, path, true); err != nil {
+		t.Fatalf("WriteJUnitOutput returned error: %v", err)
+	}
+
+	suite := readJUnitSuite(t, path)
+	if suite.Failures != 1 {
+		t.Errorf("Failures = %d, want 1", suite.Failures)
+	}
+	if suite.TestCases[0].Failure == nil {
+		t.Fatal("expected failure on PQC non-compliant port")
+	}
+}
+
+func TestWriteJUnitOutputPQCPass(t *testing.T) {
+	t.Parallel()
+
+	results := scanner.ScanResults{
+		IPResults: []scanner.IPResult{{
+			IP:     "10.0.0.1",
+			Status: "scanned",
+			PortResults: []scanner.PortResult{{
+				Port:           443,
+				Protocol:       "tcp",
+				Status:         scanner.StatusOK,
+				TLS13Supported: true,
+				MLKEMSupported: true,
+			}},
+		}},
+	}
+
+	path := filepath.Join(t.TempDir(), "pqc-pass.xml")
+	if err := WriteJUnitOutput(results, path, true); err != nil {
+		t.Fatalf("WriteJUnitOutput returned error: %v", err)
+	}
+
+	suite := readJUnitSuite(t, path)
+	if suite.Failures != 0 {
+		t.Errorf("Failures = %d, want 0", suite.Failures)
+	}
+}
+
+func TestWriteJUnitOutputSkippableStatuses(t *testing.T) {
+	t.Parallel()
+
+	results := scanner.ScanResults{
+		IPResults: []scanner.IPResult{{
+			IP:     "10.0.0.1",
+			Status: "scanned",
+			PortResults: []scanner.PortResult{
+				{Port: 1, Status: scanner.StatusNoPorts, TLS13Supported: false, MLKEMSupported: false},
+				{Port: 2, Status: scanner.StatusLocalhostOnly, TLS13Supported: false, MLKEMSupported: false},
+				{Port: 3, Status: scanner.StatusNoTLS, TLS13Supported: false, MLKEMSupported: false},
+				{Port: 4, Status: scanner.StatusProbePort, TLS13Supported: false, MLKEMSupported: false},
+			},
+		}},
+	}
+
+	path := filepath.Join(t.TempDir(), "skip.xml")
+	if err := WriteJUnitOutput(results, path, true); err != nil {
+		t.Fatalf("WriteJUnitOutput returned error: %v", err)
+	}
+
+	suite := readJUnitSuite(t, path)
+	if suite.Failures != 0 {
+		t.Errorf("Failures = %d, want 0 for skippable statuses", suite.Failures)
+	}
+	if suite.Tests != 4 {
+		t.Errorf("Tests = %d, want 4", suite.Tests)
+	}
+}
+
+func TestWriteJUnitOutputTLSComplianceFailure(t *testing.T) {
+	t.Parallel()
+
+	results := scanner.ScanResults{
+		TLSSecurityConfig: &k8s.TLSSecurityProfile{
+			TLSAdherence: configv1.TLSAdherencePolicyStrictAllComponents,
+			APIServer: &k8s.APIServerTLSProfile{
+				Type:          "Intermediate",
+				MinTLSVersion: "VersionTLS12",
+				Ciphers:       []string{"TLS_AES_128_GCM_SHA256"},
+			},
+		},
+		IPResults: []scanner.IPResult{{
+			IP:     "10.0.0.1",
+			Status: "scanned",
+			PortResults: []scanner.PortResult{{
+				Port:     443,
+				Protocol: "tcp",
+				Status:   scanner.StatusOK,
+				IngressTLSConfigCompliance: &scanner.TLSConfigComplianceResult{
+					Version: false,
+					Ciphers: true,
+				},
+			}},
+		}},
+	}
+
+	path := filepath.Join(t.TempDir(), "compliance.xml")
+	if err := WriteJUnitOutput(results, path, false); err != nil {
+		t.Fatalf("WriteJUnitOutput returned error: %v", err)
+	}
+
+	suite := readJUnitSuite(t, path)
+	if suite.Failures != 1 {
+		t.Errorf("Failures = %d, want 1", suite.Failures)
+	}
+}
+
+func TestWriteJUnitOutputCreatesDirectory(t *testing.T) {
+	t.Parallel()
+
+	results := testScanResults()
+	path := filepath.Join(t.TempDir(), "deep", "nested", "results.xml")
+
+	if err := WriteJUnitOutput(results, path, false); err != nil {
+		t.Fatalf("WriteJUnitOutput returned error: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file at %s: %v", path, err)
+	}
+}
+
+func TestWriteJUnitOutputUsesClassNameFromPod(t *testing.T) {
+	t.Parallel()
+
+	results := testScanResults()
+	path := filepath.Join(t.TempDir(), "classname.xml")
+
+	if err := WriteJUnitOutput(results, path, false); err != nil {
+		t.Fatalf("WriteJUnitOutput returned error: %v", err)
+	}
+
+	suite := readJUnitSuite(t, path)
+	if suite.TestCases[0].ClassName != "pod-a" {
+		t.Errorf("ClassName = %q, want %q (from pod name)", suite.TestCases[0].ClassName, "pod-a")
+	}
+}
+
+func TestWriteJUnitOutputUsesClassNameFromIP(t *testing.T) {
+	t.Parallel()
+
+	results := scanner.ScanResults{
+		IPResults: []scanner.IPResult{{
+			IP:     "10.0.0.1",
+			Status: "scanned",
+			PortResults: []scanner.PortResult{{
+				Port: 443, Protocol: "tcp", Status: scanner.StatusOK,
+			}},
+		}},
+	}
+
+	path := filepath.Join(t.TempDir(), "classname-ip.xml")
+	if err := WriteJUnitOutput(results, path, false); err != nil {
+		t.Fatalf("WriteJUnitOutput returned error: %v", err)
+	}
+
+	suite := readJUnitSuite(t, path)
+	if suite.TestCases[0].ClassName != "10.0.0.1" {
+		t.Errorf("ClassName = %q, want %q (from IP)", suite.TestCases[0].ClassName, "10.0.0.1")
+	}
+}

--- a/internal/stringutil/stringutil_test.go
+++ b/internal/stringutil/stringutil_test.go
@@ -1,0 +1,39 @@
+package stringutil
+
+import (
+	"testing"
+)
+
+func TestRemoveDuplicates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"no duplicates", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{"all duplicates", []string{"a", "a", "a"}, []string{"a"}},
+		{"mixed", []string{"a", "b", "a", "c", "b"}, []string{"a", "b", "c"}},
+		{"empty strings filtered", []string{"a", "", "b", ""}, []string{"a", "b"}},
+		{"nil slice", nil, nil},
+		{"empty slice", []string{}, nil},
+		{"single element", []string{"x"}, []string{"x"}},
+		{"only empty strings", []string{"", "", ""}, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := RemoveDuplicates(tt.in)
+			if len(got) != len(tt.want) {
+				t.Fatalf("RemoveDuplicates(%v) = %v (len %d), want %v (len %d)", tt.in, got, len(got), tt.want, len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("RemoveDuplicates(%v)[%d] = %q, want %q", tt.in, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/timing/timing_test.go
+++ b/internal/timing/timing_test.go
@@ -1,0 +1,130 @@
+package timing
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTrackRecordsEntry(t *testing.T) {
+	t.Parallel()
+
+	tc := &Collector{}
+	stop := tc.Track("myFunc", "target1")
+	time.Sleep(time.Millisecond)
+	stop()
+
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	if len(tc.entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(tc.entries))
+	}
+	e := tc.entries[0]
+	if e.Function != "myFunc" {
+		t.Errorf("Function = %q, want %q", e.Function, "myFunc")
+	}
+	if e.Target != "target1" {
+		t.Errorf("Target = %q, want %q", e.Target, "target1")
+	}
+	if e.Duration < time.Millisecond {
+		t.Errorf("Duration = %v, expected >= 1ms", e.Duration)
+	}
+}
+
+func TestTrackMultipleEntries(t *testing.T) {
+	t.Parallel()
+
+	tc := &Collector{}
+	stop1 := tc.Track("funcA", "")
+	stop2 := tc.Track("funcB", "")
+	stop1()
+	stop2()
+
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	if len(tc.entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(tc.entries))
+	}
+}
+
+func TestWriteReportEmpty(t *testing.T) {
+	t.Parallel()
+
+	tc := &Collector{}
+	path := filepath.Join(t.TempDir(), "report.txt")
+
+	if err := tc.WriteReport(path); err != nil {
+		t.Fatalf("WriteReport returned error: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("expected no file for empty entries")
+	}
+}
+
+func TestWriteReportContent(t *testing.T) {
+	t.Parallel()
+
+	tc := &Collector{}
+
+	now := time.Now()
+	tc.entries = []Entry{
+		{Function: "scan", Target: "host1", Duration: 100 * time.Millisecond, Start: now.Add(10 * time.Millisecond)},
+		{Function: "scan", Target: "host2", Duration: 200 * time.Millisecond, Start: now},
+		{Function: "discover", Target: "", Duration: 50 * time.Millisecond, Start: now.Add(5 * time.Millisecond)},
+	}
+
+	path := filepath.Join(t.TempDir(), "sub", "report.txt")
+	if err := tc.WriteReport(path); err != nil {
+		t.Fatalf("WriteReport returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading report: %v", err)
+	}
+	content := string(data)
+
+	// Entries should be sorted by start time: host2 (now), discover (now+5ms), host1 (now+10ms)
+	idx2 := strings.Index(content, "host2")
+	idxD := strings.Index(content, "discover")
+	idx1 := strings.Index(content, "host1")
+	if idx2 > idxD || idxD > idx1 {
+		t.Error("entries not sorted by start time")
+	}
+
+	// Summary section should contain aggregation
+	if !strings.Contains(content, "CALLS") {
+		t.Error("missing summary header")
+	}
+	// scan should show 2 calls
+	lines := strings.Split(content, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "scan") && strings.Contains(line, "2") {
+			return
+		}
+	}
+	t.Error("summary should show 2 calls for 'scan'")
+}
+
+func TestWriteReportCreatesDirectory(t *testing.T) {
+	t.Parallel()
+
+	tc := &Collector{}
+	tc.entries = []Entry{
+		{Function: "f", Target: "", Duration: time.Millisecond, Start: time.Now()},
+	}
+
+	path := filepath.Join(t.TempDir(), "deep", "nested", "report.txt")
+	if err := tc.WriteReport(path); err != nil {
+		t.Fatalf("WriteReport returned error: %v", err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file at %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add unit tests for all functions testable without a live K8s cluster
- Coverage improvement: **49.5% -> 62.5%** overall (+13 percentage points)

### Per-package breakdown

| Package | Before | After |
|---------|--------|-------|
| `internal/stringutil` | 0% | **100%** |
| `internal/timing` | 0% | **93.8%** |
| `internal/output` | 27.9% | **52.7%** |
| `internal/k8s` | 22% | **42.6%** |

### New test files
- `internal/stringutil/stringutil_test.go` — `RemoveDuplicates`
- `internal/timing/timing_test.go` — `Track`, `WriteReport`
- `internal/output/json_test.go` — `WriteJSONOutput`, `WriteOutputFiles`
- `internal/output/junit_test.go` — `WriteJUnitOutput` (PQC, TLS compliance, skippable statuses)
- `internal/k8s/component_test.go` — component/registry/maintainer extraction from images and pods
- `internal/k8s/tls_test.go` — `extractAPIServerTLS` for all profile types

### Additions to existing test files
- `discovery_test.go` — `DiscoverPortsFromPodSpec`
- `process_test.go` — `GetListenInfo`, `GetProcessName`

Jira: [CNF-23796](https://redhat.atlassian.net/browse/CNF-23796)

## Test plan

- [x] `go test ./...` passes
- [x] `go test -cover ./...` confirms coverage targets
- [x] No production code changes — test-only additions