### PR TITLE
fix: dedup and assemble scan job results based on pod namespace and name too

### DIFF
--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -449,10 +449,17 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 
 func assembleResults(startTime time.Time, totalIPs int, tlsConfig *k8s.TLSSecurityProfile, portResults ...[]portScanResult) ScanResults {
 	ipResultMap := make(map[string]*IPResult)
+	uniqueIPs := make(map[string]bool)
 
 	for _, batch := range portResults {
 		for _, r := range batch {
-			ir, ok := ipResultMap[r.ip]
+			// Pods sharing the same hosted network have the same IP.
+			// Include the pod namespace and name to make the key unique
+			// for ports. Use bracket notation to avoid ambiguity with IPv6
+			// addresses (which contain colons).
+			key := fmt.Sprintf("[%s]:%s/%s", r.ip, r.pod.Namespace, r.pod.Name)
+
+			ir, ok := ipResultMap[key]
 			if !ok {
 				ir = &IPResult{
 					IP:                 r.ip,
@@ -465,7 +472,7 @@ func assembleResults(startTime time.Time, totalIPs int, tlsConfig *k8s.TLSSecuri
 					pod := r.pod
 					ir.Pod = &pod
 				}
-				ipResultMap[r.ip] = ir
+				ipResultMap[key] = ir
 			}
 			if r.result.Port > 0 {
 				found := false
@@ -480,6 +487,7 @@ func assembleResults(startTime time.Time, totalIPs int, tlsConfig *k8s.TLSSecuri
 				}
 			}
 			ir.PortResults = append(ir.PortResults, r.result)
+			uniqueIPs[r.ip] = true
 		}
 	}
 
@@ -492,10 +500,10 @@ func assembleResults(startTime time.Time, totalIPs int, tlsConfig *k8s.TLSSecuri
 		TotalIPs:          totalIPs,
 		IPResults:         make([]IPResult, 0, len(ipResultMap)),
 		TLSSecurityConfig: tlsConfig,
+		ScannedIPs:        len(uniqueIPs),
 	}
 	for _, ir := range ipResultMap {
 		results.IPResults = append(results.IPResults, *ir)
-		results.ScannedIPs++
 	}
 
 	return results
@@ -546,16 +554,56 @@ func filterByProcessPorts(processMap map[string]map[int]string, procPorts []int)
 }
 
 func deduplicateScanJobs(jobs []ScanJob) []ScanJob {
-	seen := make(map[string]bool, len(jobs))
+	keyIndex := make(map[string]int)
 	var unique []ScanJob
+
+	specPortsCache := make(map[string]map[int]bool)
+	getSpecPorts := func(pod k8s.PodInfo) map[int]bool {
+		key := pod.Namespace + "/" + pod.Name
+		if ports, ok := specPortsCache[key]; ok {
+			return ports
+		}
+		portList, _ := k8s.DiscoverPortsFromPodSpec(pod.Pod)
+		portSet := make(map[int]bool, len(portList))
+		for _, p := range portList {
+			portSet[p] = true
+		}
+		specPortsCache[key] = portSet
+		return portSet
+	}
+
 	for _, job := range jobs {
 		key := targetKey(job.IP, strconv.Itoa(job.Port))
-		if seen[key] {
+		idx, exists := keyIndex[key]
+
+		if !exists {
+			keyIndex[key] = len(unique)
+			unique = append(unique, job)
 			continue
 		}
-		seen[key] = true
-		unique = append(unique, job)
+
+		// Select the first pod that specifies the port in its spec (if there's any)
+		// to find the owning pod. Pods sharing the same host network see the same
+		// list of ports which makes the ownership ambiguous.
+		jobDeclares := getSpecPorts(job.Pod)[job.Port]
+		existingDeclares := getSpecPorts(unique[idx].Pod)[unique[idx].Port]
+
+		if jobDeclares && existingDeclares {
+			slog.Debug("duplicate target: both pods declare port, keeping first",
+				"target", key,
+				"kept", unique[idx].Pod.Namespace+"/"+unique[idx].Pod.Name,
+				"skipped", job.Pod.Namespace+"/"+job.Pod.Name,
+				"port", job.Port)
+		} else if jobDeclares && !existingDeclares {
+			slog.Debug("duplicate target: replacing with pod that declares port",
+				"target", key,
+				"replaced", unique[idx].Pod.Namespace+"/"+unique[idx].Pod.Name,
+				"with", job.Pod.Namespace+"/"+job.Pod.Name,
+				"port", job.Port)
+			unique[idx] = job
+		}
 	}
+
 	return unique
 }
 

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -164,6 +164,154 @@ func TestAssembleResults(t *testing.T) {
 	}
 }
 
+func TestAssembleResultsWithSharedHostNetwork(t *testing.T) {
+	podDefinitions := []struct {
+		name      string
+		namespace string
+		ip        string
+		port      int32
+	}{
+		// Pods sharing IPv4 address
+		{"node-exporter", "openshift-monitoring", "10.0.1.100", 9100},
+		{"kube-proxy", "openshift-network", "10.0.1.100", 10256},
+		{"crio", "openshift-node", "10.0.1.100", 9537},
+		// Pods sharing IPv6 address
+		{"kubelet", "openshift-node", "2001:db8::1", 10250},
+		{"ovn-controller", "openshift-ovn-kubernetes", "2001:db8::1", 29102},
+	}
+
+	var batch []portScanResult
+	for _, def := range podDefinitions {
+		pod := makePod(def.name, def.namespace, def.ip, def.port)
+		batch = append(batch, portScanResult{
+			ip:     def.ip,
+			pod:    pod,
+			result: PortResult{Port: int(def.port), Status: StatusOK},
+		})
+	}
+
+	expectedPods := make(map[string]struct {
+		ip   string
+		port int
+	})
+	for _, def := range podDefinitions {
+		expectedPods[def.namespace+"/"+def.name] = struct {
+			ip   string
+			port int
+		}{def.ip, int(def.port)}
+	}
+
+	results := assembleResults(time.Now(), 0, nil, batch)
+
+	// ScannedIPs should count unique IPs (2: one IPv4, one IPv6)
+	if results.ScannedIPs != 2 {
+		t.Errorf("expected 2 unique scanned IPs, got %d", results.ScannedIPs)
+	}
+
+	// IPResults should have separate entries for each pod
+	if len(results.IPResults) != len(podDefinitions) {
+		t.Errorf("expected %d IPResults (one per pod), got %d", len(podDefinitions), len(results.IPResults))
+	}
+
+	for _, ir := range results.IPResults {
+		if ir.Pod == nil {
+			t.Errorf("unable to find Pod entry for %#v entry", ir)
+			continue
+		}
+		key := ir.Pod.Namespace + "/" + ir.Pod.Name
+		expected, ok := expectedPods[key]
+		if !ok {
+			t.Errorf("unexpected IPResult for pod %s", key)
+			continue
+		}
+		if ir.IP != expected.ip {
+			t.Errorf("%s: expected IP %s, got %s", ir.Pod.Name, expected.ip, ir.IP)
+		}
+		if len(ir.PortResults) != 1 || ir.PortResults[0].Port != expected.port {
+			t.Errorf("%s: expected port %d, got %v", ir.Pod.Name, expected.port, ir.PortResults)
+		}
+		delete(expectedPods, key)
+	}
+
+	for key := range expectedPods {
+		t.Errorf("missing IPResult for pod %s", key)
+	}
+}
+
+func TestDeduplicateScanJobs(t *testing.T) {
+	const (
+		sharedIP = "10.0.1.100"
+		port     = 9100
+	)
+
+	// Pod that declares the port in its spec
+	podWithSpec := makePod("node-exporter", "openshift-monitoring", sharedIP, port)
+
+	// Pod that doesn't declare the port (discovered via /proc)
+	podWithoutSpec := makePod("hostnetwork-pod", "openshift-node", sharedIP)
+
+	// Another pod that also declares the port
+	podAlsoWithSpec := makePod("another-exporter", "openshift-monitoring", sharedIP, port)
+
+	tests := []struct {
+		name     string
+		jobs     []ScanJob
+		expected int
+		wantPod  string
+	}{
+		{
+			name: "no duplicates",
+			jobs: []ScanJob{
+				{IP: "10.0.0.1", Port: 443, Pod: podWithSpec},
+				{IP: "10.0.0.2", Port: 443, Pod: podWithoutSpec},
+			},
+			expected: 2,
+			wantPod:  "",
+		},
+		{
+			name: "duplicate: pod with spec wins over pod without spec",
+			jobs: []ScanJob{
+				{IP: sharedIP, Port: port, Pod: podWithoutSpec},
+				{IP: sharedIP, Port: port, Pod: podWithSpec},
+			},
+			expected: 1,
+			wantPod:  "node-exporter",
+		},
+		{
+			name: "duplicate: both pods declare port, first wins",
+			jobs: []ScanJob{
+				{IP: sharedIP, Port: port, Pod: podWithSpec},
+				{IP: sharedIP, Port: port, Pod: podAlsoWithSpec},
+			},
+			expected: 1,
+			wantPod:  "node-exporter",
+		},
+		{
+			name: "duplicate: pod without spec first, then pod with spec replaces it",
+			jobs: []ScanJob{
+				{IP: sharedIP, Port: port, Pod: podWithoutSpec},
+				{IP: sharedIP, Port: port, Pod: podWithSpec},
+			},
+			expected: 1,
+			wantPod:  "node-exporter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deduplicateScanJobs(tt.jobs)
+			if len(result) != tt.expected {
+				t.Errorf("expected %d jobs after dedup, got %d", tt.expected, len(result))
+			}
+			if tt.wantPod != "" && len(result) > 0 {
+				if result[0].Pod.Name != tt.wantPod {
+					t.Errorf("expected pod %s to be selected, got %s", tt.wantPod, result[0].Pod.Name)
+				}
+			}
+		})
+	}
+}
+
 func TestGetMinVersionValue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Pods that share the same host network (hostNetwork=true) see the same list of ports. The current dedup and assemle code picks pods with the first unique IP it sees and ignores every other pod. Even though ports on the same host network are owned by different pods. Which makes the final results claim a port owned by a different pod.

Fixes: https://github.com/openshift/tls-scanner/issues/62