### PR TITLE
CNF-23975: Rename v1 import alias to corev1 for k8s.io/api/core/v1

### DIFF
--- a/internal/k8s/component.go
+++ b/internal/k8s/component.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -26,7 +26,7 @@ func (c *Client) GetOpenshiftComponentFromImage(image string) (*OpenshiftCompone
 // GetOpenshiftComponentFromPod extracts component information from a pod,
 // preferring pod labels for the component name but using image metadata for
 // source location and maintainer information.
-func (c *Client) GetOpenshiftComponentFromPod(pod v1.Pod) (*OpenshiftComponent, error) {
+func (c *Client) GetOpenshiftComponentFromPod(pod corev1.Pod) (*OpenshiftComponent, error) {
 	if len(pod.Spec.Containers) == 0 {
 		return nil, fmt.Errorf("pod has no containers")
 	}
@@ -162,7 +162,7 @@ func (c *Client) extractRegistryFromImage(image string) string {
 //  3. label named 'app.kubernetes.io/name'
 //  4. container.Name
 //  5. name determined from container.Image
-func (c *Client) extractComponentFromPod(pod v1.Pod, container v1.Container) string {
+func (c *Client) extractComponentFromPod(pod corev1.Pod, container corev1.Container) string {
 	if component, exists := pod.Labels["app"]; exists {
 		return component
 	}
@@ -178,7 +178,7 @@ func (c *Client) extractComponentFromPod(pod v1.Pod, container v1.Container) str
 	return c.extractComponentNameFromImage(container.Image)
 }
 
-func (c *Client) extractMaintainerFromPod(pod v1.Pod) string {
+func (c *Client) extractMaintainerFromPod(pod corev1.Pod) string {
 	if strings.HasPrefix(pod.Namespace, "openshift-") {
 		return "openshift"
 	}

--- a/internal/k8s/component_test.go
+++ b/internal/k8s/component_test.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -155,43 +155,43 @@ func TestExtractComponentFromPod(t *testing.T) {
 	tests := []struct {
 		name      string
 		labels    map[string]string
-		container v1.Container
+		container corev1.Container
 		want      string
 	}{
 		{
 			name:      "app label",
 			labels:    map[string]string{"app": "my-app"},
-			container: v1.Container{Name: "ctr", Image: "quay.io/x/y:z"},
+			container: corev1.Container{Name: "ctr", Image: "quay.io/x/y:z"},
 			want:      "my-app",
 		},
 		{
 			name:      "component label",
 			labels:    map[string]string{"component": "my-component"},
-			container: v1.Container{Name: "ctr", Image: "quay.io/x/y:z"},
+			container: corev1.Container{Name: "ctr", Image: "quay.io/x/y:z"},
 			want:      "my-component",
 		},
 		{
 			name:      "app.kubernetes.io/name label",
 			labels:    map[string]string{"app.kubernetes.io/name": "k8s-app"},
-			container: v1.Container{Name: "ctr", Image: "quay.io/x/y:z"},
+			container: corev1.Container{Name: "ctr", Image: "quay.io/x/y:z"},
 			want:      "k8s-app",
 		},
 		{
 			name:      "app label takes precedence over component",
 			labels:    map[string]string{"app": "winner", "component": "loser"},
-			container: v1.Container{Name: "ctr"},
+			container: corev1.Container{Name: "ctr"},
 			want:      "winner",
 		},
 		{
 			name:      "falls back to container name",
 			labels:    map[string]string{},
-			container: v1.Container{Name: "my-container", Image: "nginx"},
+			container: corev1.Container{Name: "my-container", Image: "nginx"},
 			want:      "my-container",
 		},
 		{
 			name:      "falls back to image name",
 			labels:    map[string]string{},
-			container: v1.Container{Name: "", Image: "quay.io/org/my-image:v1"},
+			container: corev1.Container{Name: "", Image: "quay.io/org/my-image:v1"},
 			want:      "my-image",
 		},
 	}
@@ -199,7 +199,7 @@ func TestExtractComponentFromPod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			pod := v1.Pod{
+			pod := corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Labels: tt.labels},
 			}
 			got := c.extractComponentFromPod(pod, tt.container)
@@ -229,7 +229,7 @@ func TestExtractMaintainerFromPod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			pod := v1.Pod{
+			pod := corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: tt.namespace,
 					Labels:    tt.labels,

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
@@ -24,13 +24,13 @@ const (
 	procDiscoveryShell = `cat /proc/net/tcp /proc/net/tcp6 2>/dev/null; printf '\n` + inodeMapSentinel + `\n'; for p in /proc/[0-9]*; do [ -f "$p/comm" ] || continue; comm=$(cat "$p/comm" 2>/dev/null) || continue; for fd in "$p"/fd/*; do target=$(readlink "$fd" 2>/dev/null) || continue; case "$target" in socket:\[*) inode=${target#socket:[}; inode=${inode%]}; echo "$inode $comm";; esac; done; done`
 )
 
-func DiscoverPortsFromPodSpec(pod *v1.Pod) ([]int, error) {
+func DiscoverPortsFromPodSpec(pod *corev1.Pod) ([]int, error) {
 	slog.Debug("discovering ports from API server", "namespace", pod.Namespace, "pod", pod.Name)
 
 	var ports []int
 	for _, container := range pod.Spec.Containers {
 		for _, port := range container.Ports {
-			if port.Protocol == v1.ProtocolTCP {
+			if port.Protocol == corev1.ProtocolTCP {
 				ports = append(ports, int(port.ContainerPort))
 			}
 		}
@@ -38,7 +38,7 @@ func DiscoverPortsFromPodSpec(pod *v1.Pod) ([]int, error) {
 
 	for _, container := range pod.Spec.InitContainers {
 		for _, port := range container.Ports {
-			if port.Protocol == v1.ProtocolTCP {
+			if port.Protocol == corev1.ProtocolTCP {
 				ports = append(ports, int(port.ContainerPort))
 			}
 		}
@@ -56,14 +56,14 @@ func DiscoverPortsFromPodSpec(pod *v1.Pod) ([]int, error) {
 // DiscoverPortsFromSecondaryContainers returns TCP ports from containers other than execContainer.
 //
 // TODO(refactor): extract shared tcpPortsFromContainers helper; drop never-used error return from DiscoverPortsFromPodSpec
-func DiscoverPortsFromSecondaryContainers(pod *v1.Pod, execContainer string) []int {
+func DiscoverPortsFromSecondaryContainers(pod *corev1.Pod, execContainer string) []int {
 	var ports []int
 	for _, container := range pod.Spec.Containers {
 		if container.Name == execContainer {
 			continue
 		}
 		for _, port := range container.Ports {
-			if port.Protocol == v1.ProtocolTCP {
+			if port.Protocol == corev1.ProtocolTCP {
 				ports = append(ports, int(port.ContainerPort))
 			}
 		}
@@ -89,7 +89,7 @@ func (c *Client) DiscoverPortsFromProc(pod PodInfo) ([]int, error) {
 		Namespace(pod.Namespace).
 		SubResource("exec")
 
-	req.VersionedParams(&v1.PodExecOptions{
+	req.VersionedParams(&corev1.PodExecOptions{
 		Container: containerName,
 		Command:   command,
 		Stdin:     false,
@@ -266,14 +266,14 @@ func decodeProcNetAddr(hexAddr string) string {
 //
 // Port references that use named ports (e.g. "healthz") are resolved against
 // each container's declared Ports list.
-func GetPlaintextProbePorts(pod *v1.Pod) map[int]bool {
+func GetPlaintextProbePorts(pod *corev1.Pod) map[int]bool {
 	result := make(map[int]bool)
 
 	allContainers := append(pod.Spec.Containers, pod.Spec.InitContainers...)
 	for _, container := range allContainers {
 		namedPorts := buildNamedPortMap(container.Ports)
 
-		for _, probe := range []*v1.Probe{
+		for _, probe := range []*corev1.Probe{
 			container.LivenessProbe,
 			container.ReadinessProbe,
 			container.StartupProbe,
@@ -283,7 +283,7 @@ func GetPlaintextProbePorts(pod *v1.Pod) map[int]bool {
 			}
 			switch {
 			case probe.HTTPGet != nil:
-				if probe.HTTPGet.Scheme == v1.URISchemeHTTPS {
+				if probe.HTTPGet.Scheme == corev1.URISchemeHTTPS {
 					// HTTPS probe — TLS is explicitly in use; keep scanning this port.
 					continue
 				}
@@ -304,7 +304,7 @@ func GetPlaintextProbePorts(pod *v1.Pod) map[int]bool {
 }
 
 // buildNamedPortMap returns a name → port number map from a container's port list.
-func buildNamedPortMap(ports []v1.ContainerPort) map[string]int {
+func buildNamedPortMap(ports []corev1.ContainerPort) map[string]int {
 	m := make(map[string]int, len(ports))
 	for _, p := range ports {
 		if p.Name != "" {

--- a/internal/k8s/discovery_test.go
+++ b/internal/k8s/discovery_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"testing"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
@@ -243,18 +243,18 @@ func TestDiscoverPortsFromPodSpec(t *testing.T) {
 
 	tests := []struct {
 		name string
-		pod  *v1.Pod
+		pod  *corev1.Pod
 		want []int
 	}{
 		{
 			name: "TCP ports from containers",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{Containers: []v1.Container{{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{
 					Name: "c",
-					Ports: []v1.ContainerPort{
-						{ContainerPort: 443, Protocol: v1.ProtocolTCP},
-						{ContainerPort: 8443, Protocol: v1.ProtocolTCP},
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: 443, Protocol: corev1.ProtocolTCP},
+						{ContainerPort: 8443, Protocol: corev1.ProtocolTCP},
 					},
 				}}},
 			},
@@ -262,13 +262,13 @@ func TestDiscoverPortsFromPodSpec(t *testing.T) {
 		},
 		{
 			name: "UDP ports excluded",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{Containers: []v1.Container{{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{
 					Name: "c",
-					Ports: []v1.ContainerPort{
-						{ContainerPort: 443, Protocol: v1.ProtocolTCP},
-						{ContainerPort: 53, Protocol: v1.ProtocolUDP},
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: 443, Protocol: corev1.ProtocolTCP},
+						{ContainerPort: 53, Protocol: corev1.ProtocolUDP},
 					},
 				}}},
 			},
@@ -276,16 +276,16 @@ func TestDiscoverPortsFromPodSpec(t *testing.T) {
 		},
 		{
 			name: "init container ports included",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
 						Name:  "main",
-						Ports: []v1.ContainerPort{{ContainerPort: 443, Protocol: v1.ProtocolTCP}},
+						Ports: []corev1.ContainerPort{{ContainerPort: 443, Protocol: corev1.ProtocolTCP}},
 					}},
-					InitContainers: []v1.Container{{
+					InitContainers: []corev1.Container{{
 						Name:  "init",
-						Ports: []v1.ContainerPort{{ContainerPort: 9090, Protocol: v1.ProtocolTCP}},
+						Ports: []corev1.ContainerPort{{ContainerPort: 9090, Protocol: corev1.ProtocolTCP}},
 					}},
 				},
 			},
@@ -293,19 +293,19 @@ func TestDiscoverPortsFromPodSpec(t *testing.T) {
 		},
 		{
 			name: "no ports",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec:       v1.PodSpec{Containers: []v1.Container{{Name: "c"}}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c"}}},
 			},
 			want: nil,
 		},
 		{
 			name: "multiple containers",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{Containers: []v1.Container{
-					{Name: "c1", Ports: []v1.ContainerPort{{ContainerPort: 443, Protocol: v1.ProtocolTCP}}},
-					{Name: "c2", Ports: []v1.ContainerPort{{ContainerPort: 8443, Protocol: v1.ProtocolTCP}}},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "c1", Ports: []corev1.ContainerPort{{ContainerPort: 443, Protocol: corev1.ProtocolTCP}}},
+					{Name: "c2", Ports: []corev1.ContainerPort{{ContainerPort: 8443, Protocol: corev1.ProtocolTCP}}},
 				}},
 			},
 			want: []int{443, 8443},
@@ -333,15 +333,15 @@ func TestDiscoverPortsFromSecondaryContainers(t *testing.T) {
 
 	tests := []struct {
 		name          string
-		pod           *v1.Pod
+		pod           *corev1.Pod
 		execContainer string
 		want          []int
 	}{
 		{
 			name: "single container returns nothing",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{Containers: []v1.Container{
-					{Name: "main", Ports: []v1.ContainerPort{{ContainerPort: 443, Protocol: v1.ProtocolTCP}}},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "main", Ports: []corev1.ContainerPort{{ContainerPort: 443, Protocol: corev1.ProtocolTCP}}},
 				}},
 			},
 			execContainer: "main",
@@ -349,10 +349,10 @@ func TestDiscoverPortsFromSecondaryContainers(t *testing.T) {
 		},
 		{
 			name: "excludes exec container ports",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{Containers: []v1.Container{
-					{Name: "main", Ports: []v1.ContainerPort{{ContainerPort: 443, Protocol: v1.ProtocolTCP}}},
-					{Name: "sidecar", Ports: []v1.ContainerPort{{ContainerPort: 8443, Protocol: v1.ProtocolTCP}}},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "main", Ports: []corev1.ContainerPort{{ContainerPort: 443, Protocol: corev1.ProtocolTCP}}},
+					{Name: "sidecar", Ports: []corev1.ContainerPort{{ContainerPort: 8443, Protocol: corev1.ProtocolTCP}}},
 				}},
 			},
 			execContainer: "main",
@@ -360,11 +360,11 @@ func TestDiscoverPortsFromSecondaryContainers(t *testing.T) {
 		},
 		{
 			name: "multiple secondary containers",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{Containers: []v1.Container{
-					{Name: "main", Ports: []v1.ContainerPort{{ContainerPort: 443, Protocol: v1.ProtocolTCP}}},
-					{Name: "sidecar1", Ports: []v1.ContainerPort{{ContainerPort: 8443, Protocol: v1.ProtocolTCP}}},
-					{Name: "sidecar2", Ports: []v1.ContainerPort{{ContainerPort: 9090, Protocol: v1.ProtocolTCP}}},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "main", Ports: []corev1.ContainerPort{{ContainerPort: 443, Protocol: corev1.ProtocolTCP}}},
+					{Name: "sidecar1", Ports: []corev1.ContainerPort{{ContainerPort: 8443, Protocol: corev1.ProtocolTCP}}},
+					{Name: "sidecar2", Ports: []corev1.ContainerPort{{ContainerPort: 9090, Protocol: corev1.ProtocolTCP}}},
 				}},
 			},
 			execContainer: "main",
@@ -372,12 +372,12 @@ func TestDiscoverPortsFromSecondaryContainers(t *testing.T) {
 		},
 		{
 			name: "UDP ports excluded",
-			pod: &v1.Pod{
-				Spec: v1.PodSpec{Containers: []v1.Container{
-					{Name: "main", Ports: []v1.ContainerPort{{ContainerPort: 443, Protocol: v1.ProtocolTCP}}},
-					{Name: "sidecar", Ports: []v1.ContainerPort{
-						{ContainerPort: 8443, Protocol: v1.ProtocolTCP},
-						{ContainerPort: 53, Protocol: v1.ProtocolUDP},
+			pod: &corev1.Pod{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
+					{Name: "main", Ports: []corev1.ContainerPort{{ContainerPort: 443, Protocol: corev1.ProtocolTCP}}},
+					{Name: "sidecar", Ports: []corev1.ContainerPort{
+						{ContainerPort: 8443, Protocol: corev1.ProtocolTCP},
+						{ContainerPort: 53, Protocol: corev1.ProtocolUDP},
 					}},
 				}},
 			},
@@ -402,33 +402,33 @@ func TestDiscoverPortsFromSecondaryContainers(t *testing.T) {
 func intPort(n int) intstr.IntOrString      { return intstr.FromInt(n) }
 func namedPort(s string) intstr.IntOrString { return intstr.FromString(s) }
 
-func httpProbe(port intstr.IntOrString) *v1.Probe {
-	return &v1.Probe{ProbeHandler: v1.ProbeHandler{HTTPGet: &v1.HTTPGetAction{Port: port, Scheme: v1.URISchemeHTTP}}}
+func httpProbe(port intstr.IntOrString) *corev1.Probe {
+	return &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Port: port, Scheme: corev1.URISchemeHTTP}}}
 }
 
-func httpsProbe(port intstr.IntOrString) *v1.Probe {
-	return &v1.Probe{ProbeHandler: v1.ProbeHandler{HTTPGet: &v1.HTTPGetAction{Port: port, Scheme: v1.URISchemeHTTPS}}}
+func httpsProbe(port intstr.IntOrString) *corev1.Probe {
+	return &corev1.Probe{ProbeHandler: corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Port: port, Scheme: corev1.URISchemeHTTPS}}}
 }
 
-func tcpProbe(port intstr.IntOrString) *v1.Probe {
-	return &v1.Probe{ProbeHandler: v1.ProbeHandler{TCPSocket: &v1.TCPSocketAction{Port: port}}}
+func tcpProbe(port intstr.IntOrString) *corev1.Probe {
+	return &corev1.Probe{ProbeHandler: corev1.ProbeHandler{TCPSocket: &corev1.TCPSocketAction{Port: port}}}
 }
 
-func grpcProbe(port int32) *v1.Probe {
-	return &v1.Probe{ProbeHandler: v1.ProbeHandler{GRPC: &v1.GRPCAction{Port: port}}}
+func grpcProbe(port int32) *corev1.Probe {
+	return &corev1.Probe{ProbeHandler: corev1.ProbeHandler{GRPC: &corev1.GRPCAction{Port: port}}}
 }
 
 func TestGetPlaintextProbePorts(t *testing.T) {
 	tests := []struct {
 		name string
-		pod  *v1.Pod
+		pod  *corev1.Pod
 		want map[int]bool
 	}{
 		{
 			name: "http liveness probe by integer port",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{Containers: []v1.Container{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
 					{Name: "c", LivenessProbe: httpProbe(intPort(10301))},
 				}},
 			},
@@ -436,13 +436,13 @@ func TestGetPlaintextProbePorts(t *testing.T) {
 		},
 		{
 			name: "http liveness probe via named port",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{Containers: []v1.Container{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
 					{
 						Name: "c",
-						Ports: []v1.ContainerPort{
-							{Name: "healthz", ContainerPort: 10301, Protocol: v1.ProtocolTCP},
+						Ports: []corev1.ContainerPort{
+							{Name: "healthz", ContainerPort: 10301, Protocol: corev1.ProtocolTCP},
 						},
 						LivenessProbe: httpProbe(namedPort("healthz")),
 					},
@@ -452,9 +452,9 @@ func TestGetPlaintextProbePorts(t *testing.T) {
 		},
 		{
 			name: "https liveness probe is NOT skipped",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{Containers: []v1.Container{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
 					{Name: "c", LivenessProbe: httpsProbe(intPort(8443))},
 				}},
 			},
@@ -462,9 +462,9 @@ func TestGetPlaintextProbePorts(t *testing.T) {
 		},
 		{
 			name: "tcp readiness probe",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{Containers: []v1.Container{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
 					{Name: "c", ReadinessProbe: tcpProbe(intPort(9090))},
 				}},
 			},
@@ -472,9 +472,9 @@ func TestGetPlaintextProbePorts(t *testing.T) {
 		},
 		{
 			name: "grpc startup probe",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{Containers: []v1.Container{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
 					{Name: "c", StartupProbe: grpcProbe(5000)},
 				}},
 			},
@@ -482,9 +482,9 @@ func TestGetPlaintextProbePorts(t *testing.T) {
 		},
 		{
 			name: "all three probe types across multiple containers",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{Containers: []v1.Container{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
 					{
 						Name:           "c1",
 						LivenessProbe:  httpProbe(intPort(8081)),
@@ -500,9 +500,9 @@ func TestGetPlaintextProbePorts(t *testing.T) {
 		},
 		{
 			name: "named port not found returns zero — port excluded",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{Containers: []v1.Container{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
 					{Name: "c", LivenessProbe: httpProbe(namedPort("missing"))},
 				}},
 			},
@@ -510,17 +510,17 @@ func TestGetPlaintextProbePorts(t *testing.T) {
 		},
 		{
 			name: "init container plaintext probe",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
 						{Name: "main"},
 					},
-					InitContainers: []v1.Container{
+					InitContainers: []corev1.Container{
 						{
 							Name: "init",
-							Ports: []v1.ContainerPort{
-								{Name: "healthz", ContainerPort: 9440, Protocol: v1.ProtocolTCP},
+							Ports: []corev1.ContainerPort{
+								{Name: "healthz", ContainerPort: 9440, Protocol: corev1.ProtocolTCP},
 							},
 							LivenessProbe: httpProbe(namedPort("healthz")),
 						},
@@ -531,9 +531,9 @@ func TestGetPlaintextProbePorts(t *testing.T) {
 		},
 		{
 			name: "no probes",
-			pod: &v1.Pod{
+			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "ns"},
-				Spec: v1.PodSpec{Containers: []v1.Container{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{
 					{Name: "c"},
 				}},
 			},

--- a/internal/k8s/types.go
+++ b/internal/k8s/types.go
@@ -7,7 +7,7 @@ import (
 	configclientset "github.com/openshift/client-go/config/clientset/versioned"
 	mcfgclientset "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	operatorclientset "github.com/openshift/client-go/operator/clientset/versioned"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -19,7 +19,7 @@ type PodInfo struct {
 	Image      string
 	IPs        []string
 	Containers []string
-	Pod        *v1.Pod `json:"-"`
+	Pod        *corev1.Pod `json:"-"`
 }
 
 type ListenInfo struct {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/tls-scanner/internal/k8s"
@@ -18,14 +18,14 @@ import (
 )
 
 func makePod(name, namespace, ip string, ports ...int32) k8s.PodInfo {
-	var containerPorts []v1.ContainerPort
+	var containerPorts []corev1.ContainerPort
 	for _, p := range ports {
-		containerPorts = append(containerPorts, v1.ContainerPort{ContainerPort: p, Protocol: v1.ProtocolTCP})
+		containerPorts = append(containerPorts, corev1.ContainerPort{ContainerPort: p, Protocol: corev1.ProtocolTCP})
 	}
-	pod := &v1.Pod{
+	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{{Name: "main", Ports: containerPorts}},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main", Ports: containerPorts}},
 		},
 	}
 	return k8s.PodInfo{
@@ -712,20 +712,20 @@ func TestWriteTargetsFile(t *testing.T) {
 func TestDiscoverPortsFromPodSpec(t *testing.T) {
 	t.Parallel()
 
-	pod := &v1.Pod{
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
 				{
-					Ports: []v1.ContainerPort{
-						{ContainerPort: 8443, Protocol: v1.ProtocolTCP},
-						{ContainerPort: 53, Protocol: v1.ProtocolUDP},
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: 8443, Protocol: corev1.ProtocolTCP},
+						{ContainerPort: 53, Protocol: corev1.ProtocolUDP},
 					},
 				},
 			},
-			InitContainers: []v1.Container{
+			InitContainers: []corev1.Container{
 				{
-					Ports: []v1.ContainerPort{
-						{ContainerPort: 9443, Protocol: v1.ProtocolTCP},
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: 9443, Protocol: corev1.ProtocolTCP},
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

- Rename the `v1` import alias to `corev1` for `k8s.io/api/core/v1` across all files
- Aligns with existing conventions: `configv1`, `metav1`, `operatorv1`
- Pure rename — no logic changes

Jira: [CNF-23975](https://redhat.atlassian.net/browse/CNF-23975)

### Files changed (7)

**Production:** `internal/k8s/types.go`, `component.go`, `discovery.go`, `process.go`
**Tests:** `internal/k8s/component_test.go`, `discovery_test.go`, `internal/scanner/scanner_test.go`

### Similar to

- rh-ecosystem-edge/eco-goinfra#921
- rh-ecosystem-edge/eco-goinfra#239
- rh-ecosystem-edge/eco-goinfra#387
- rh-ecosystem-edge/eco-goinfra#694
- rh-ecosystem-edge/eco-goinfra#711

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `grep -rn 'v1 "k8s.io/api/core/v1"'` returns zero matches