### PR TITLE
fix(k8s): use net.SplitHostPort for lsof IPv6 parsing and preserve spec-declared ports

### DIFF
--- a/internal/k8s/component.go
+++ b/internal/k8s/component.go
@@ -129,7 +129,6 @@ func (c *Client) getComponentFromClusterMetadata(image string) (*OpenshiftCompon
 	}, nil
 }
 
-
 func (c *Client) extractComponentNameFromImage(image string) string {
 	parts := strings.Split(image, "/")
 	if len(parts) > 0 {
@@ -158,11 +157,11 @@ func (c *Client) extractRegistryFromImage(image string) string {
 
 // extractComponentFromPod returns a component name for a pod based on the following order
 // of precedence:
-//   1. label named 'app' 
-//   2. label named 'component'
-//   3. label named 'app.kubernetes.io/name'
-//   4. container.Name
-//   5. name determined from container.Image 
+//  1. label named 'app'
+//  2. label named 'component'
+//  3. label named 'app.kubernetes.io/name'
+//  4. container.Name
+//  5. name determined from container.Image
 func (c *Client) extractComponentFromPod(pod v1.Pod, container v1.Container) string {
 	if component, exists := pod.Labels["app"]; exists {
 		return component

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -123,6 +123,8 @@ func (c *Client) DiscoverPortsFromProc(pod PodInfo) ([]int, error) {
 	return ports, nil
 }
 
+// TODO(refactor): move ParseProcNetTCPWithAddrs + decodeProcNetAddr to internal/netdiscovery
+
 // ParseProcNetTCPWithAddrs parses /proc/net/tcp (and /proc/net/tcp6) output and
 // returns a map of port → decoded listen address for every socket in the LISTEN
 // state.

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -48,6 +48,24 @@ func DiscoverPortsFromPodSpec(pod *v1.Pod) ([]int, error) {
 	return ports, nil
 }
 
+// DiscoverPortsFromSecondaryContainers returns TCP ports from containers other than lsofContainer.
+//
+// TODO(refactor): extract shared tcpPortsFromContainers helper; drop never-used error return from DiscoverPortsFromPodSpec
+func DiscoverPortsFromSecondaryContainers(pod *v1.Pod, lsofContainer string) []int {
+	var ports []int
+	for _, container := range pod.Spec.Containers {
+		if container.Name == lsofContainer {
+			continue
+		}
+		for _, port := range container.Ports {
+			if port.Protocol == v1.ProtocolTCP {
+				ports = append(ports, int(port.ContainerPort))
+			}
+		}
+	}
+	return ports
+}
+
 func (c *Client) DiscoverPortsFromProc(pod PodInfo) ([]int, error) {
 	if len(pod.Containers) == 0 {
 		return nil, fmt.Errorf("pod %s/%s has no containers", pod.Namespace, pod.Name)

--- a/internal/k8s/discovery_test.go
+++ b/internal/k8s/discovery_test.go
@@ -268,6 +268,77 @@ func TestDiscoverPortsFromPodSpec(t *testing.T) {
 	}
 }
 
+func TestDiscoverPortsFromSecondaryContainers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		pod           *v1.Pod
+		lsofContainer string
+		want          []int
+	}{
+		{
+			name: "single container returns nothing",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "main", Ports: []v1.ContainerPort{{ContainerPort: 443, Protocol: v1.ProtocolTCP}}},
+				}},
+			},
+			lsofContainer: "main",
+			want:          nil,
+		},
+		{
+			name: "excludes lsof container ports",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "main", Ports: []v1.ContainerPort{{ContainerPort: 443, Protocol: v1.ProtocolTCP}}},
+					{Name: "sidecar", Ports: []v1.ContainerPort{{ContainerPort: 8443, Protocol: v1.ProtocolTCP}}},
+				}},
+			},
+			lsofContainer: "main",
+			want:          []int{8443},
+		},
+		{
+			name: "multiple secondary containers",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "main", Ports: []v1.ContainerPort{{ContainerPort: 443, Protocol: v1.ProtocolTCP}}},
+					{Name: "sidecar1", Ports: []v1.ContainerPort{{ContainerPort: 8443, Protocol: v1.ProtocolTCP}}},
+					{Name: "sidecar2", Ports: []v1.ContainerPort{{ContainerPort: 9090, Protocol: v1.ProtocolTCP}}},
+				}},
+			},
+			lsofContainer: "main",
+			want:          []int{8443, 9090},
+		},
+		{
+			name: "UDP ports excluded",
+			pod: &v1.Pod{
+				Spec: v1.PodSpec{Containers: []v1.Container{
+					{Name: "main", Ports: []v1.ContainerPort{{ContainerPort: 443, Protocol: v1.ProtocolTCP}}},
+					{Name: "sidecar", Ports: []v1.ContainerPort{
+						{ContainerPort: 8443, Protocol: v1.ProtocolTCP},
+						{ContainerPort: 53, Protocol: v1.ProtocolUDP},
+					}},
+				}},
+			},
+			lsofContainer: "main",
+			want:          []int{8443},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := DiscoverPortsFromSecondaryContainers(tt.pod, tt.lsofContainer)
+			sort.Ints(got)
+			sort.Ints(tt.want)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("DiscoverPortsFromSecondaryContainers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func intPort(n int) intstr.IntOrString      { return intstr.FromInt(n) }
 func namedPort(s string) intstr.IntOrString { return intstr.FromString(s) }
 

--- a/internal/k8s/process.go
+++ b/internal/k8s/process.go
@@ -121,6 +121,9 @@ func ParseLsofOutput(output string, ips []string, namespace, podName string) (ma
 			}
 		}
 	}
+	if err := sc.Err(); err != nil {
+		slog.Warn("lsof: scanner error, output may be truncated", "namespace", namespace, "pod", podName, "error", err)
+	}
 
 	return processMap, listenInfoMap
 }

--- a/internal/k8s/process.go
+++ b/internal/k8s/process.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"strconv"
 	"strings"
 	"time"
@@ -70,53 +71,61 @@ func (c *Client) GetProcessMapForPod(pod PodInfo) (map[string]map[int]string, ma
 		slog.Debug("lsof returned empty stdout", "namespace", pod.Namespace, "pod", pod.Name)
 	}
 
-	scanner := bufio.NewScanner(&stdout)
-	var currentProcess string
-	for scanner.Scan() {
-		line := scanner.Text()
-		slog.Debug("parsing lsof output line", "namespace", pod.Namespace, "pod", pod.Name, "line", line)
-		if len(line) > 1 {
-			fieldType := line[0]
-			fieldValue := line[1:]
+	processMap, listenInfoMap = ParseLsofOutput(stdout.String(), pod.IPs)
+	return processMap, listenInfoMap, nil
+}
 
-			switch fieldType {
-			case 'c':
-				currentProcess = fieldValue
-			case 'n':
-				parts := strings.Split(fieldValue, ":")
-				if len(parts) == 2 {
-					listenAddr := parts[0]
-					portStr := parts[1]
-					port, err := strconv.Atoi(portStr)
-					if err == nil {
-						for _, ip := range pod.IPs {
-							if _, ok := processMap[ip]; !ok {
-								processMap[ip] = make(map[int]string)
-							}
-							if _, ok := listenInfoMap[ip]; !ok {
-								listenInfoMap[ip] = make(map[int]ListenInfo)
-							}
-							processMap[ip][port] = currentProcess
-							listenInfoMap[ip][port] = ListenInfo{
-								Port:          port,
-								ListenAddress: listenAddr,
-								ProcessName:   currentProcess,
-							}
-							slog.Debug("mapped port to process", "namespace", pod.Namespace, "pod", pod.Name, "ip", ip, "port", port, "process", currentProcess, "listenAddr", listenAddr)
-						}
-					} else {
-						slog.Error("converting port to integer", "namespace", pod.Namespace, "pod", pod.Name, "portStr", portStr, "line", line)
-					}
-				} else {
-					slog.Warn("unexpected lsof network address format", "namespace", pod.Namespace, "pod", pod.Name, "address", fieldValue)
+// ParseLsofOutput parses `lsof -i -sTCP:LISTEN -P -n -F cn` output and returns
+// per-IP maps of port→process name and port→ListenInfo. Uses net.SplitHostPort
+// to correctly handle both IPv4 ("*:9099") and IPv6 ("[::]:8443") addresses.
+//
+// TODO(refactor): collapse to single ListenInfo map return; move to internal/netdiscovery
+func ParseLsofOutput(output string, ips []string) (map[string]map[int]string, map[string]map[int]ListenInfo) {
+	processMap := make(map[string]map[int]string)
+	listenInfoMap := make(map[string]map[int]ListenInfo)
+
+	sc := bufio.NewScanner(strings.NewReader(output))
+	var currentProcess string
+	for sc.Scan() {
+		line := sc.Text()
+		if len(line) < 2 {
+			continue
+		}
+		switch line[0] {
+		case 'c':
+			currentProcess = line[1:]
+		case 'n':
+			host, portStr, err := net.SplitHostPort(line[1:])
+			if err != nil {
+				slog.Warn("lsof: cannot parse address", "address", line[1:], "error", err)
+				continue
+			}
+			port, err := strconv.Atoi(portStr)
+			if err != nil {
+				slog.Error("lsof: invalid port number", "port", portStr)
+				continue
+			}
+			for _, ip := range ips {
+				if processMap[ip] == nil {
+					processMap[ip] = make(map[int]string)
+				}
+				if listenInfoMap[ip] == nil {
+					listenInfoMap[ip] = make(map[int]ListenInfo)
+				}
+				processMap[ip][port] = currentProcess
+				listenInfoMap[ip][port] = ListenInfo{
+					Port:          port,
+					ListenAddress: host,
+					ProcessName:   currentProcess,
 				}
 			}
 		}
 	}
 
-	return processMap, listenInfoMap, nil
+	return processMap, listenInfoMap
 }
 
+// TODO(refactor): return map[int]bool port set; stop caching into processNameMap
 func (c *Client) GetAndCachePodProcesses(pod PodInfo) map[string]map[int]string {
 	c.processCacheMutex.Lock()
 	if c.processDiscoveryAttempted[pod.Name] {
@@ -204,6 +213,7 @@ func (c *Client) GetListenInfo(ip string, port int) (ListenInfo, bool) {
 	return ListenInfo{}, false
 }
 
+// TODO(refactor): remove — redundant with GetListenInfo().ProcessName
 func (c *Client) GetProcessName(ip string, port int) (string, bool) {
 	c.processCacheMutex.Lock()
 	defer c.processCacheMutex.Unlock()

--- a/internal/k8s/process.go
+++ b/internal/k8s/process.go
@@ -71,7 +71,7 @@ func (c *Client) GetProcessMapForPod(pod PodInfo) (map[string]map[int]string, ma
 		slog.Debug("lsof returned empty stdout", "namespace", pod.Namespace, "pod", pod.Name)
 	}
 
-	processMap, listenInfoMap = ParseLsofOutput(stdout.String(), pod.IPs)
+	processMap, listenInfoMap = ParseLsofOutput(stdout.String(), pod.IPs, pod.Namespace, pod.Name)
 	return processMap, listenInfoMap, nil
 }
 
@@ -80,7 +80,7 @@ func (c *Client) GetProcessMapForPod(pod PodInfo) (map[string]map[int]string, ma
 // to correctly handle both IPv4 ("*:9099") and IPv6 ("[::]:8443") addresses.
 //
 // TODO(refactor): collapse to single ListenInfo map return; move to internal/netdiscovery
-func ParseLsofOutput(output string, ips []string) (map[string]map[int]string, map[string]map[int]ListenInfo) {
+func ParseLsofOutput(output string, ips []string, namespace, podName string) (map[string]map[int]string, map[string]map[int]ListenInfo) {
 	processMap := make(map[string]map[int]string)
 	listenInfoMap := make(map[string]map[int]ListenInfo)
 
@@ -97,12 +97,12 @@ func ParseLsofOutput(output string, ips []string) (map[string]map[int]string, ma
 		case 'n':
 			host, portStr, err := net.SplitHostPort(line[1:])
 			if err != nil {
-				slog.Warn("lsof: cannot parse address", "address", line[1:], "error", err)
+				slog.Warn("lsof: cannot parse address", "namespace", namespace, "pod", podName, "address", line[1:], "error", err)
 				continue
 			}
 			port, err := strconv.Atoi(portStr)
 			if err != nil {
-				slog.Error("lsof: invalid port number", "port", portStr)
+				slog.Error("lsof: invalid port number", "namespace", namespace, "pod", podName, "port", portStr)
 				continue
 			}
 			for _, ip := range ips {

--- a/internal/k8s/process_test.go
+++ b/internal/k8s/process_test.go
@@ -224,7 +224,7 @@ func TestParseLsofOutput(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotProc, gotListen := ParseLsofOutput(tt.output, tt.ips)
+			gotProc, gotListen := ParseLsofOutput(tt.output, tt.ips, "test-ns", "test-pod")
 			for ip, wantPorts := range tt.wantProcesses {
 				for port, wantName := range wantPorts {
 					if gotProc[ip][port] != wantName {

--- a/internal/k8s/process_test.go
+++ b/internal/k8s/process_test.go
@@ -154,6 +154,100 @@ func TestGetProcessName(t *testing.T) {
 	}
 }
 
+func TestParseLsofOutput(t *testing.T) {
+	tests := []struct {
+		name          string
+		output        string
+		ips           []string
+		wantProcesses map[string]map[int]string
+		wantListen    map[string]map[int]ListenInfo
+	}{
+		{
+			name:   "ipv4 wildcard",
+			output: "p1\ncmyproc\nn*:9099\n",
+			ips:    []string{"10.0.0.1"},
+			wantProcesses: map[string]map[int]string{
+				"10.0.0.1": {9099: "myproc"},
+			},
+			wantListen: map[string]map[int]ListenInfo{
+				"10.0.0.1": {9099: {Port: 9099, ListenAddress: "*", ProcessName: "myproc"}},
+			},
+		},
+		{
+			name:   "ipv4 localhost",
+			output: "p1\ncmyproc\nn127.0.0.1:8080\n",
+			ips:    []string{"10.0.0.1"},
+			wantProcesses: map[string]map[int]string{
+				"10.0.0.1": {8080: "myproc"},
+			},
+			wantListen: map[string]map[int]ListenInfo{
+				"10.0.0.1": {8080: {Port: 8080, ListenAddress: "127.0.0.1", ProcessName: "myproc"}},
+			},
+		},
+		{
+			name:   "ipv6 wildcard bracket notation",
+			output: "p1\nckube-rbac\nn[::]:8443\n",
+			ips:    []string{"10.0.0.1"},
+			wantProcesses: map[string]map[int]string{
+				"10.0.0.1": {8443: "kube-rbac"},
+			},
+			wantListen: map[string]map[int]ListenInfo{
+				"10.0.0.1": {8443: {Port: 8443, ListenAddress: "::", ProcessName: "kube-rbac"}},
+			},
+		},
+		{
+			name:   "ipv6 localhost bracket notation",
+			output: "p1\ncmetrics\nn[::1]:9090\n",
+			ips:    []string{"10.0.0.1"},
+			wantProcesses: map[string]map[int]string{
+				"10.0.0.1": {9090: "metrics"},
+			},
+			wantListen: map[string]map[int]ListenInfo{
+				"10.0.0.1": {9090: {Port: 9090, ListenAddress: "::1", ProcessName: "metrics"}},
+			},
+		},
+		{
+			name:   "mixed ipv4 and ipv6",
+			output: "p1\ncmain\nn*:9091\np2\nckube-rbac\nn[::]:8443\n",
+			ips:    []string{"10.0.0.1"},
+			wantProcesses: map[string]map[int]string{
+				"10.0.0.1": {9091: "main", 8443: "kube-rbac"},
+			},
+			wantListen: map[string]map[int]ListenInfo{
+				"10.0.0.1": {
+					9091: {Port: 9091, ListenAddress: "*", ProcessName: "main"},
+					8443: {Port: 8443, ListenAddress: "::", ProcessName: "kube-rbac"},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotProc, gotListen := ParseLsofOutput(tt.output, tt.ips)
+			for ip, wantPorts := range tt.wantProcesses {
+				for port, wantName := range wantPorts {
+					if gotProc[ip][port] != wantName {
+						t.Errorf("processMap[%s][%d] = %q, want %q", ip, port, gotProc[ip][port], wantName)
+					}
+				}
+			}
+			for ip, wantPorts := range tt.wantListen {
+				for port, wantInfo := range wantPorts {
+					gotInfo, ok := gotListen[ip][port]
+					if !ok {
+						t.Errorf("listenInfoMap missing ip=%s port=%d", ip, port)
+						continue
+					}
+					if gotInfo != wantInfo {
+						t.Errorf("listenInfoMap[%s][%d] = %+v, want %+v", ip, port, gotInfo, wantInfo)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestIsLocalhostAddr(t *testing.T) {
 	tests := []struct {
 		addr string

--- a/internal/k8s/types.go
+++ b/internal/k8s/types.go
@@ -66,7 +66,7 @@ type Client struct {
 	clientset      *kubernetes.Clientset
 	restCfg        *rest.Config
 	dynamicClient  dynamic.Interface
-	processNameMap map[string]map[int]string
+	processNameMap map[string]map[int]string // TODO(refactor): redundant with listenInfoMap — remove
 	listenInfoMap  map[string]map[int]ListenInfo
 	// procListenAddrMap holds the decoded listen address for every port seen in
 	// /proc/net/tcp(6). It covers all containers in a pod (shared network

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -95,7 +95,7 @@ func DiscoverTargets(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client
 				}
 
 				if pod.Pod.Spec.HostNetwork && processMap != nil && len(procPorts) > 0 {
-					procPorts = filterByProcessPorts(processMap, procPorts)
+					procPorts = filterByProcessPorts(processMap, procPorts, specPorts)
 				}
 
 				// When /proc data is available use it as the ground truth — only
@@ -541,12 +541,16 @@ func LimitPodsToIPCount(pods []k8s.PodInfo, maxIPs int) []k8s.PodInfo {
 	return limitedPods
 }
 
-func filterByProcessPorts(processMap map[string]map[int]string, procPorts []int) []int {
+// filterByProcessPorts keeps procPorts owned by this pod (via lsof or pod spec).
+func filterByProcessPorts(processMap map[string]map[int]string, procPorts []int, specPorts []int) []int {
 	owned := make(map[int]bool)
 	for _, portMap := range processMap {
 		for port := range portMap {
 			owned[port] = true
 		}
+	}
+	for _, p := range specPorts {
+		owned[p] = true
 	}
 	var filtered []int
 	for _, p := range procPorts {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -95,7 +95,11 @@ func DiscoverTargets(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client
 				}
 
 				if pod.Pod.Spec.HostNetwork && processMap != nil && len(procPorts) > 0 {
-					procPorts = filterByProcessPorts(processMap, procPorts, specPorts)
+					var secondarySpecPorts []int
+					if len(pod.Containers) > 1 {
+						secondarySpecPorts = k8s.DiscoverPortsFromSecondaryContainers(pod.Pod, pod.Containers[0])
+					}
+					procPorts = filterByProcessPorts(processMap, procPorts, secondarySpecPorts)
 				}
 
 				// When /proc data is available use it as the ground truth — only

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -729,6 +729,15 @@ func TestFilterByProcessPorts(t *testing.T) {
 			specPorts: []int{9091},
 			want:      []int{9091},
 		},
+		{
+			name: "nil specPorts — only lsof-owned ports kept",
+			processMap: map[string]map[int]string{
+				"10.0.0.1": {9091: "main"},
+			},
+			procPorts: []int{9091, 6443, 10257},
+			specPorts: nil,
+			want:      []int{9091},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -692,6 +692,57 @@ func TestDiscoverPortsFromPodSpec(t *testing.T) {
 	}
 }
 
+func TestFilterByProcessPorts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		processMap map[string]map[int]string
+		procPorts  []int
+		specPorts  []int
+		want       []int
+	}{
+		{
+			name: "keeps lsof-mapped ports",
+			processMap: map[string]map[int]string{
+				"10.0.0.1": {9091: "main", 9043: "sidecar"},
+			},
+			procPorts: []int{9091, 9043, 6443, 10257},
+			specPorts: []int{9091, 9043},
+			want:      []int{9091, 9043},
+		},
+		{
+			name: "spec-declared port preserved when lsof misses it",
+			processMap: map[string]map[int]string{
+				"10.0.0.1": {9091: "main", 9043: "sidecar"},
+			},
+			procPorts: []int{9091, 9043, 8443, 6443, 10257},
+			specPorts: []int{9091, 9043, 8443},
+			want:      []int{9091, 9043, 8443},
+		},
+		{
+			name: "unowned port not in spec still dropped",
+			processMap: map[string]map[int]string{
+				"10.0.0.1": {9091: "main"},
+			},
+			procPorts: []int{9091, 6443, 10257},
+			specPorts: []int{9091},
+			want:      []int{9091},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := filterByProcessPorts(tt.processMap, tt.procPorts, tt.specPorts)
+			slices.Sort(got)
+			slices.Sort(tt.want)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("filterByProcessPorts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHasPQCComplianceFailures(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- Replace hand-rolled `strings.Split(":")` lsof address parsing with `net.SplitHostPort`, fixing silent drops of IPv6 bracket-notation addresses like `[::]:8443`
- Include pod spec-declared ports in the host-network filter so ports owned by secondary containers (invisible to lsof due to PID namespace isolation) are not incorrectly dropped
- Extract `ParseLsofOutput` as a standalone testable function

Fixes: #63
Closes: #26
