### PR TITLE
CNF-24070: Use %w error wrapping in fmt.Errorf calls

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -24,7 +24,7 @@ func NewClient() (*Client, error) {
 		loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
 		config, err = clientcmd.BuildConfigFromFlags("", loadingRules.GetDefaultFilename())
 		if err != nil {
-			return nil, fmt.Errorf("could not get kubernetes config: %v", err)
+			return nil, fmt.Errorf("could not get kubernetes config: %w", err)
 		}
 		slog.Info("Successfully created Kubernetes client from kubeconfig file")
 	}
@@ -36,22 +36,22 @@ func NewClient() (*Client, error) {
 
 	configClient, err := configclientset.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("could not create openshift config client: %v", err)
+		return nil, fmt.Errorf("could not create openshift config client: %w", err)
 	}
 
 	operatorClient, err := operatorclientset.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("could not create openshift operator client: %v", err)
+		return nil, fmt.Errorf("could not create openshift operator client: %w", err)
 	}
 
 	mcfgClient, err := mcfgclientset.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("could not create openshift machineconfig client: %v", err)
+		return nil, fmt.Errorf("could not create openshift machineconfig client: %w", err)
 	}
 
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("could not create dynamic client: %v", err)
+		return nil, fmt.Errorf("could not create dynamic client: %w", err)
 	}
 
 	namespace := "default"

--- a/internal/k8s/component.go
+++ b/internal/k8s/component.go
@@ -104,7 +104,7 @@ func (c *Client) getComponentFromClusterMetadata(image string) (*OpenshiftCompon
 
 	pods, err := c.clientset.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list pods for image metadata: %v", err)
+		return nil, fmt.Errorf("failed to list pods for image metadata: %w", err)
 	}
 
 	for _, pod := range pods.Items {
@@ -128,7 +128,6 @@ func (c *Client) getComponentFromClusterMetadata(image string) (*OpenshiftCompon
 		IsBundle:            false,
 	}, nil
 }
-
 
 func (c *Client) extractComponentNameFromImage(image string) string {
 	parts := strings.Split(image, "/")
@@ -158,11 +157,11 @@ func (c *Client) extractRegistryFromImage(image string) string {
 
 // extractComponentFromPod returns a component name for a pod based on the following order
 // of precedence:
-//   1. label named 'app' 
-//   2. label named 'component'
-//   3. label named 'app.kubernetes.io/name'
-//   4. container.Name
-//   5. name determined from container.Image 
+//  1. label named 'app'
+//  2. label named 'component'
+//  3. label named 'app.kubernetes.io/name'
+//  4. container.Name
+//  5. name determined from container.Image
 func (c *Client) extractComponentFromPod(pod v1.Pod, container v1.Container) string {
 	if component, exists := pod.Labels["app"]; exists {
 		return component

--- a/internal/k8s/process.go
+++ b/internal/k8s/process.go
@@ -43,7 +43,7 @@ func (c *Client) GetProcessMapForPod(pod PodInfo) (map[string]map[int]string, ma
 
 	executor, err := remotecommand.NewSPDYExecutor(c.restCfg, "POST", req.URL())
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create executor for pod %s: %v", pod.Name, err)
+		return nil, nil, fmt.Errorf("failed to create executor for pod %s: %w", pod.Name, err)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -63,7 +63,7 @@ func (c *Client) GetProcessMapForPod(pod PodInfo) (map[string]map[int]string, ma
 		if ctx.Err() == context.DeadlineExceeded {
 			return nil, nil, fmt.Errorf("lsof exec TIMED OUT in pod %s/%s (30s)", pod.Namespace, pod.Name)
 		}
-		return nil, nil, fmt.Errorf("exec failed on pod %s: %v, stdout: %s, stderr: %s", pod.Name, err, stdout.String(), stderr.String())
+		return nil, nil, fmt.Errorf("exec failed on pod %s (stdout: %s, stderr: %s): %w", pod.Name, stdout.String(), stderr.String(), err)
 	}
 
 	if stdout.Len() == 0 {

--- a/internal/k8s/tls.go
+++ b/internal/k8s/tls.go
@@ -50,7 +50,7 @@ func (c *Client) GetTLSSecurityProfile() (*TLSSecurityProfile, error) {
 func (c *Client) getIngressControllerTLS(fallback *APIServerTLSProfile) (*IngressTLSProfile, error) {
 	ingress, err := c.operatorClient.OperatorV1().IngressControllers("openshift-ingress-operator").Get(context.Background(), "default", metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get IngressController custom resource: %v", err)
+		return nil, fmt.Errorf("failed to get IngressController custom resource: %w", err)
 	}
 
 	profile := &IngressTLSProfile{}
@@ -125,7 +125,7 @@ func extractAPIServerTLS(apiserver *configv1.APIServer) *APIServerTLSProfile {
 func (c *Client) getKubeletTLS(fallback *APIServerTLSProfile) (*KubeletTLSProfile, error) {
 	kubeletConfigs, err := c.mcfgClient.MachineconfigurationV1().KubeletConfigs().List(context.Background(), metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list KubeletConfigs: %v", err)
+		return nil, fmt.Errorf("failed to list KubeletConfigs: %w", err)
 	}
 
 	for _, kc := range kubeletConfigs.Items {

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -28,7 +28,7 @@ func WriteCSVOutput(results scanner.ScanResults, filename string) error {
 
 	file, err := os.Create(filename)
 	if err != nil {
-		return fmt.Errorf("failed to create CSV file: %v", err)
+		return fmt.Errorf("failed to create CSV file: %w", err)
 	}
 	defer file.Close()
 
@@ -36,7 +36,7 @@ func WriteCSVOutput(results scanner.ScanResults, filename string) error {
 	defer writer.Flush()
 
 	if err := writer.Write(csvColumns); err != nil {
-		return fmt.Errorf("failed to write CSV header: %v", err)
+		return fmt.Errorf("failed to write CSV header: %w", err)
 	}
 
 	rowCount := 0
@@ -180,7 +180,7 @@ func WriteCSVOutput(results scanner.ScanResults, filename string) error {
 
 			row := buildCSVRow(csvColumns, rowData)
 			if err := writer.Write(row); err != nil {
-				return fmt.Errorf("failed to write CSV row: %v", err)
+				return fmt.Errorf("failed to write CSV row: %w", err)
 			}
 			rowCount++
 		}
@@ -199,7 +199,7 @@ func WriteScanErrorsCSV(results scanner.ScanResults, filename string) error {
 
 	file, err := os.Create(filename)
 	if err != nil {
-		return fmt.Errorf("failed to create scan errors CSV file: %v", err)
+		return fmt.Errorf("failed to create scan errors CSV file: %w", err)
 	}
 	defer file.Close()
 
@@ -208,7 +208,7 @@ func WriteScanErrorsCSV(results scanner.ScanResults, filename string) error {
 
 	header := []string{"IP", "Port", "Error Type", "Error Message", "Pod Name", "Namespace", "Container"}
 	if err := writer.Write(header); err != nil {
-		return fmt.Errorf("failed to write scan errors CSV header: %v", err)
+		return fmt.Errorf("failed to write scan errors CSV header: %w", err)
 	}
 
 	for _, scanError := range results.ScanErrors {
@@ -223,7 +223,7 @@ func WriteScanErrorsCSV(results scanner.ScanResults, filename string) error {
 		}
 
 		if err := writer.Write(row); err != nil {
-			return fmt.Errorf("failed to write scan error row: %v", err)
+			return fmt.Errorf("failed to write scan error row: %w", err)
 		}
 	}
 

--- a/internal/output/json.go
+++ b/internal/output/json.go
@@ -14,14 +14,14 @@ import (
 func WriteJSONOutput(data interface{}, filename string) error {
 	file, err := os.Create(filename)
 	if err != nil {
-		return fmt.Errorf("failed to create output file: %v", err)
+		return fmt.Errorf("failed to create output file: %w", err)
 	}
 	defer file.Close()
 
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(data); err != nil {
-		return fmt.Errorf("failed to encode JSON: %v", err)
+		return fmt.Errorf("failed to encode JSON: %w", err)
 	}
 
 	slog.Info("JSON output written", "path", filename)
@@ -34,7 +34,7 @@ func WriteOutputFiles(results scanner.ScanResults, artifactDir, jsonFile, csvFil
 	}
 
 	if err := os.MkdirAll(artifactDir, 0755); err != nil {
-		return fmt.Errorf("could not create artifact directory %s: %v", artifactDir, err)
+		return fmt.Errorf("could not create artifact directory %s: %w", artifactDir, err)
 	}
 	slog.Info("artifacts directory created", "path", artifactDir)
 

--- a/internal/output/junit.go
+++ b/internal/output/junit.go
@@ -110,23 +110,23 @@ func WriteJUnitOutput(scanResults scanner.ScanResults, filename string, pqcCheck
 
 	dir := filepath.Dir(filename)
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("could not create directory for JUnit report: %v", err)
+		return fmt.Errorf("could not create directory for JUnit report: %w", err)
 	}
 
 	file, err := os.Create(filename)
 	if err != nil {
-		return fmt.Errorf("could not create JUnit report file: %v", err)
+		return fmt.Errorf("could not create JUnit report file: %w", err)
 	}
 	defer file.Close()
 
 	if _, err := file.WriteString(xml.Header); err != nil {
-		return fmt.Errorf("failed to write XML header to JUnit report: %v", err)
+		return fmt.Errorf("failed to write XML header to JUnit report: %w", err)
 	}
 
 	encoder := xml.NewEncoder(file)
 	encoder.Indent("", "  ")
 	if err := encoder.Encode(testSuite); err != nil {
-		return fmt.Errorf("could not encode JUnit report: %v", err)
+		return fmt.Errorf("could not encode JUnit report: %w", err)
 	}
 
 	return nil

--- a/internal/timing/timing.go
+++ b/internal/timing/timing.go
@@ -53,12 +53,12 @@ func (tc *Collector) WriteReport(filename string) error {
 
 	dir := filepath.Dir(filename)
 	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("could not create directory for timing report: %v", err)
+		return fmt.Errorf("could not create directory for timing report: %w", err)
 	}
 
 	f, err := os.Create(filename)
 	if err != nil {
-		return fmt.Errorf("could not create timing report: %v", err)
+		return fmt.Errorf("could not create timing report: %w", err)
 	}
 	defer f.Close()
 


### PR DESCRIPTION
## Summary

- Replace `%v` with `%w` for error arguments in all 25 `fmt.Errorf` calls across 8 files
- Preserves the error chain so callers can use `errors.Is` and `errors.As` for programmatic error handling ([Go blog: Working with Errors in Go 1.13](https://go.dev/blog/go1.13-errors))
- One non-trivial change: reordered arguments in `process.go` to move `err` to the final position, since [`%w` must be the last format verb](https://pkg.go.dev/fmt#Errorf)

Jira: [CNF-24070](https://redhat.atlassian.net/browse/CNF-24070)

### Files changed (8)

**k8s:** `client.go` (5), `process.go` (2), `tls.go` (2), `component.go` (1)
**output:** `csv.go` (6), `junit.go` (4), `json.go` (3)
**timing:** `timing.go` (2)

## Related to

- [redhat-best-practices-for-k8s/certsuite#3730](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3730) — `%w` error wrapping in certsuite (open)
- [openshift-kni/commatrix#482](https://github.com/openshift-kni/commatrix/pull/482) — `%w` error wrapping in commatrix (merged)
- [crc-org/crc#5180](https://github.com/crc-org/crc/pull/5180) — `%w` error wrapping in crc (merged)
- [openshift-kni/lifecycle-agent#6319](https://github.com/openshift-kni/lifecycle-agent/pull/6319) — bare error wrapping in lifecycle-agent (open)
- [redhat-best-practices-for-k8s/certsuite#3633](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3633) — bare error wrapping in certsuite (merged)
- [redhat-best-practices-for-k8s/certsuite#3627](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3627) — bare error wrapping in certsuite (merged)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `make lint` passes
- [x] `grep -rn 'fmt.Errorf.*%v' --include='*.go'` returns zero matches (excluding tests)