### PR TITLE
CNF-24259: Consolidate duplicate normalizeHost functions

### DIFF
--- a/cmd/tls-scanner/main.go
+++ b/cmd/tls-scanner/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openshift/tls-scanner/internal/k8s"
 	"github.com/openshift/tls-scanner/internal/output"
 	"github.com/openshift/tls-scanner/internal/scanner"
+	"github.com/openshift/tls-scanner/internal/stringutil"
 	"github.com/openshift/tls-scanner/internal/timing"
 )
 
@@ -311,7 +312,7 @@ func run(args []string) (exitCode int) {
 		return 1
 	}
 
-	jobs := []scanner.ScanJob{{IP: normalizeHost(*host), Port: portNum}}
+	jobs := []scanner.ScanJob{{IP: stringutil.NormalizeHost(*host), Port: portNum}}
 
 	if *dryRun {
 		output.PrintDryRunTargets(jobs)
@@ -361,13 +362,5 @@ func parseTarget(target string) (string, int, error) {
 		return "", 0, err
 	}
 
-	return normalizeHost(host), portNum, nil
-}
-
-func normalizeHost(host string) string {
-	host = strings.TrimSpace(host)
-	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") && len(host) >= 2 {
-		return host[1 : len(host)-1]
-	}
-	return host
+	return stringutil.NormalizeHost(host), portNum, nil
 }

--- a/internal/stringutil/stringutil.go
+++ b/internal/stringutil/stringutil.go
@@ -1,5 +1,16 @@
 package stringutil
 
+import "strings"
+
+// NormalizeHost trims whitespace and strips IPv6 square brackets from a host string.
+func NormalizeHost(host string) string {
+	host = strings.TrimSpace(host)
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") && len(host) >= 2 {
+		return host[1 : len(host)-1]
+	}
+	return host
+}
+
 // RemoveDuplicates returns a new slice with duplicates and empty strings removed,
 // preserving the original order.
 func RemoveDuplicates(slice []string) []string {

--- a/internal/stringutil/stringutil_test.go
+++ b/internal/stringutil/stringutil_test.go
@@ -4,6 +4,35 @@ import (
 	"testing"
 )
 
+func TestNormalizeHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain IPv4", "10.0.0.1", "10.0.0.1"},
+		{"bracketed IPv6", "[::1]", "::1"},
+		{"bracketed full IPv6", "[fd2e:6f44:5dd8::16]", "fd2e:6f44:5dd8::16"},
+		{"no brackets", "fd2e:6f44:5dd8::16", "fd2e:6f44:5dd8::16"},
+		{"whitespace trimmed", "  10.0.0.1  ", "10.0.0.1"},
+		{"whitespace with brackets", "  [::1]  ", "::1"},
+		{"empty string", "", ""},
+		{"single bracket only", "[", "["},
+		{"hostname", "example.com", "example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := NormalizeHost(tt.in); got != tt.want {
+				t.Errorf("NormalizeHost(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestRemoveDuplicates(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Replace three identical host-normalization functions with a single exported `stringutil.NormalizeHost()`
- All three trimmed whitespace and stripped IPv6 square brackets with the same 5-line body
- Add 9 test cases covering IPv4, IPv6 (bracketed/unbracketed), whitespace, empty, and hostname inputs

Jira: [CNF-24259](https://redhat.atlassian.net/browse/CNF-24259)

### Functions removed

| Function | File |
|----------|------|
| `normalizeHost()` | `cmd/tls-scanner/main.go` |
| `normalizeTargetHost()` | `internal/scanner/scanner.go` |
| `normalizeTemplateHost()` | `internal/scanner/template.go` |

### Replaced with

`stringutil.NormalizeHost()` in `internal/stringutil/stringutil.go`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `make lint` passes
- [x] New `TestNormalizeHost` covers 9 input variants