### PR TITLE
CNF-24706: Make scan timeouts configurable via CLI flags

### DIFF
--- a/cmd/tls-scanner/main.go
+++ b/cmd/tls-scanner/main.go
@@ -72,6 +72,8 @@ func run(args []string) (exitCode int) {
 	dryRun := fs.Bool("dry-run", false, "Discover scan targets and print them without scanning")
 	showVersion := fs.Bool("version", false, "Print version and exit")
 	logLevel := fs.String("log-level", "info", "Log level: debug, info, warn, error")
+	scanTimeoutPerTarget := fs.Int("scan-timeout-per-target", scanner.DefaultScanTimeouts.PerTargetSeconds, "Seconds per target for batch scan timeout calculation")
+	connectTimeout := fs.Int("connect-timeout", scanner.DefaultScanTimeouts.ConnectTimeout, "Timeout in seconds for testssl.sh connect and openssl operations")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -112,6 +114,16 @@ func run(args []string) (exitCode int) {
 		}
 		fmt.Printf("Template written to %s\n", *generateTemplate)
 		return 0
+	}
+
+	if *scanTimeoutPerTarget <= 0 || *connectTimeout <= 0 {
+		fmt.Fprintln(os.Stderr, "Error: --scan-timeout-per-target and --connect-timeout must be positive integers")
+		return 2
+	}
+
+	timeouts := scanner.ScanTimeouts{
+		PerTargetSeconds: *scanTimeoutPerTarget,
+		ConnectTimeout:   *connectTimeout,
 	}
 
 	policy, err := scanner.Policy()
@@ -174,7 +186,7 @@ func run(args []string) (exitCode int) {
 			return 0
 		}
 
-		scanResults := scanner.Scan(jobs, *concurrentScans, nil, nil, policy)
+		scanResults := scanner.Scan(jobs, *concurrentScans, nil, nil, policy, timeouts)
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
@@ -197,7 +209,7 @@ func run(args []string) (exitCode int) {
 			return 1
 		}
 
-		scanResults := scanner.Scan(jobs, *concurrentScans, nil, nil, policy)
+		scanResults := scanner.Scan(jobs, *concurrentScans, nil, nil, policy, timeouts)
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
@@ -260,7 +272,7 @@ func run(args []string) (exitCode int) {
 	}
 
 	if len(pods) > 0 {
-		scanResults := scanner.PerformClusterScan(pods, *concurrentScans, client, policy)
+		scanResults := scanner.PerformClusterScan(pods, *concurrentScans, client, policy, timeouts)
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
@@ -289,7 +301,7 @@ func run(args []string) (exitCode int) {
 		return 0
 	}
 
-	scanResults := scanner.Scan(jobs, *concurrentScans, client, nil, policy)
+	scanResults := scanner.Scan(jobs, *concurrentScans, client, nil, policy, timeouts)
 	finalScanResults = &scanResults
 
 	if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {

--- a/internal/k8s/discovery.go
+++ b/internal/k8s/discovery.go
@@ -17,7 +17,10 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 )
 
-const procStateListen = "0A"
+const (
+	procStateListen = "0A"
+	podExecTimeout  = 30 * time.Second
+)
 
 func DiscoverPortsFromPodSpec(pod *v1.Pod) ([]int, error) {
 	slog.Debug("discovering ports from API server", "namespace", pod.Namespace, "pod", pod.Name)
@@ -99,7 +102,7 @@ func (c *Client) DiscoverPortsFromProc(pod PodInfo) ([]int, error) {
 		return nil, fmt.Errorf("failed to create executor for pod %s/%s: %w", pod.Namespace, pod.Name, err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), podExecTimeout)
 	defer cancel()
 
 	var stdout, stderr bytes.Buffer

--- a/internal/k8s/process.go
+++ b/internal/k8s/process.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -47,7 +46,7 @@ func (c *Client) GetProcessMapForPod(pod PodInfo) (map[string]map[int]string, ma
 		return nil, nil, fmt.Errorf("failed to create executor for pod %s: %w", pod.Name, err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), podExecTimeout)
 	defer cancel()
 
 	var stdout, stderr bytes.Buffer

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -220,7 +220,7 @@ func DiscoverTargets(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client
 	return DiscoveryResults{ScanJobs: scanJobs, Skipped: skipped}
 }
 
-func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client, policy *ComponentPolicy) ScanResults {
+func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client, policy *ComponentPolicy, timeouts ScanTimeouts) ScanResults {
 	defer timing.Timings.Track("performClusterScan", "")()
 	startTime := time.Now()
 
@@ -250,7 +250,7 @@ MAX_PARALLEL (testssl): %d
 
 	discovery := DiscoverTargets(pods, concurrentScans, client)
 
-	batchResults := batchScan(discovery.ScanJobs, concurrentScans, client, tlsConfig, policy)
+	batchResults := batchScan(discovery.ScanJobs, concurrentScans, client, tlsConfig, policy, timeouts)
 
 	results := assembleResults(startTime, totalIPs, tlsConfig, discovery.Skipped, batchResults)
 
@@ -272,7 +272,7 @@ MAX_PARALLEL (testssl): %d
 
 // Scan runs a batch testssl.sh scan on pre-built scan jobs.
 // Used by --targets and single-host paths (no k8s discovery needed).
-func Scan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile, policy *ComponentPolicy) ScanResults {
+func Scan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile, policy *ComponentPolicy, timeouts ScanTimeouts) ScanResults {
 	defer timing.Timings.Track("scan", "")()
 	startTime := time.Now()
 
@@ -287,7 +287,7 @@ func Scan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8
 	fmt.Printf("MAX_PARALLEL: %d\n", concurrentScans)
 	fmt.Printf("========================================\n\n")
 
-	batchResults := batchScan(jobs, concurrentScans, client, tlsConfig, policy)
+	batchResults := batchScan(jobs, concurrentScans, client, tlsConfig, policy, timeouts)
 	results := assembleResults(startTime, 0, tlsConfig, batchResults)
 
 	duration := time.Since(startTime)
@@ -305,7 +305,7 @@ func Scan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8
 	return results
 }
 
-func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile, policy *ComponentPolicy) []portScanResult {
+func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile, policy *ComponentPolicy, timeouts ScanTimeouts) []portScanResult {
 	if len(jobs) == 0 {
 		return nil
 	}
@@ -335,14 +335,16 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 	defer os.Remove(outputFileName)
 
 	slog.Info("running testssl.sh batch scan", "targets", len(targets), "maxParallel", concurrentScans)
-	timeout := time.Duration(len(targets)*90+120) * time.Second
+	perTarget := time.Duration(timeouts.PerTargetSeconds) * time.Second
+	timeout := perTarget*time.Duration(len(targets)) + 2*time.Minute
 	slog.Debug("batch timeout set", "timeout", timeout)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	connectTimeoutStr := strconv.Itoa(timeouts.ConnectTimeout)
 	cmd := exec.CommandContext(ctx, "testssl.sh", "-p", "-s", "-f", "-E",
-		"--connect-timeout", "5",
-		"--openssl-timeout", "5",
+		"--connect-timeout", connectTimeoutStr,
+		"--openssl-timeout", connectTimeoutStr,
 		"--file", targetsFile,
 		"--jsonfile", outputFileName,
 		"--warnings", "off",

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -41,7 +41,7 @@ func TestScanWithMockTestSSL(t *testing.T) {
 		{IP: "10.0.0.1", Port: 443},
 		{IP: "10.0.0.2", Port: 8443},
 	}
-	results := Scan(jobs, 2, nil, nil, testPolicy(t))
+	results := Scan(jobs, 2, nil, nil, testPolicy(t), DefaultScanTimeouts)
 
 	if results.ScannedIPs != 2 {
 		t.Fatalf("expected 2 scanned IPs, got %d", results.ScannedIPs)
@@ -65,7 +65,7 @@ func TestScanPQCEnrichment(t *testing.T) {
 	testutil.InstallMockTestSSL(t)
 
 	jobs := []ScanJob{{IP: "10.0.0.1", Port: 443}}
-	results := Scan(jobs, 1, nil, nil, testPolicy(t))
+	results := Scan(jobs, 1, nil, nil, testPolicy(t), DefaultScanTimeouts)
 
 	pr := results.IPResults[0].PortResults[0]
 
@@ -98,7 +98,7 @@ func TestPerformClusterScanWithMockPods(t *testing.T) {
 		makePod("no-ports", "openshift-console", "10.128.0.30"),
 	}
 
-	results := PerformClusterScan(pods, 2, nil, testPolicy(t))
+	results := PerformClusterScan(pods, 2, nil, testPolicy(t), DefaultScanTimeouts)
 
 	if results.ScannedIPs != 3 {
 		t.Errorf("expected 3 scanned IPs (including no-ports), got %d", results.ScannedIPs)

--- a/internal/scanner/testssl_integration_test.go
+++ b/internal/scanner/testssl_integration_test.go
@@ -33,7 +33,7 @@ func TestIntegrationSingleTarget(t *testing.T) {
 	jobs := []ScanJob{{IP: tgt.ip, Port: tgt.port}}
 
 	start := time.Now()
-	results := batchScan(jobs, 1, nil, nil, testPolicy(t))
+	results := batchScan(jobs, 1, nil, nil, testPolicy(t), DefaultScanTimeouts)
 	elapsed := time.Since(start)
 
 	t.Logf("Single target %s (%s:%d): %v", tgt.desc, tgt.ip, tgt.port, elapsed)
@@ -73,7 +73,7 @@ func TestIntegrationBatchTargets(t *testing.T) {
 	}
 
 	start := time.Now()
-	results := batchScan(jobs, 4, nil, nil, testPolicy(t))
+	results := batchScan(jobs, 4, nil, nil, testPolicy(t), DefaultScanTimeouts)
 	elapsed := time.Since(start)
 
 	t.Logf("Batch %d targets (MAX_PARALLEL=4): %v (%.1fs/target)",
@@ -102,12 +102,12 @@ func TestIntegrationParallelScaling(t *testing.T) {
 
 	t.Log("--- Sequential run (MAX_PARALLEL=1) ---")
 	start := time.Now()
-	seqResults := batchScan(jobs, 1, nil, nil, testPolicy(t))
+	seqResults := batchScan(jobs, 1, nil, nil, testPolicy(t), DefaultScanTimeouts)
 	sequential := time.Since(start)
 
 	t.Log("--- Parallel run (MAX_PARALLEL=", len(jobs), ") ---")
 	start = time.Now()
-	parResults := batchScan(jobs, len(jobs), nil, nil, testPolicy(t))
+	parResults := batchScan(jobs, len(jobs), nil, nil, testPolicy(t), DefaultScanTimeouts)
 	parallel := time.Since(start)
 
 	speedup := sequential.Seconds() / parallel.Seconds()

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -152,6 +152,16 @@ type KeyExchangeInfo struct {
 	ForwardSecrecy *ForwardSecrecy `json:"forward_secrecy,omitempty"`
 }
 
+type ScanTimeouts struct {
+	PerTargetSeconds int
+	ConnectTimeout   int
+}
+
+var DefaultScanTimeouts = ScanTimeouts{
+	PerTargetSeconds: 90,
+	ConnectTimeout:   5,
+}
+
 type ScanJob struct {
 	IP        string
 	Port      int


### PR DESCRIPTION
## Summary

The batch scan timeout formula and testssl.sh connect/openssl timeouts were hardcoded, preventing users from tuning for large clusters or slow networks.

- Add `--scan-timeout-per-target` (default 90s) — controls per-target component of the batch timeout formula
- Add `--connect-timeout` (default 5s) — controls testssl.sh `--connect-timeout` and `--openssl-timeout`
- Validate both flags are positive integers
- Centralize pod exec timeout as a package constant (no flag — internal detail)

## Test plan

- [x] `make lint` — 0 issues
- [x] `go test ./...` — all pass
- [ ] `--help` shows new flags with correct defaults
- [ ] `--connect-timeout 0` rejected with exit code 2
- [ ] Non-default values propagate to testssl.sh invocation (verify via `--log-level debug`)