### PR TITLE
CNF-25075: Deduplicate TLS profile resolution logic

### DIFF
--- a/internal/k8s/tls.go
+++ b/internal/k8s/tls.go
@@ -48,6 +48,14 @@ func (c *Client) GetTLSSecurityProfile() (*TLSSecurityProfile, error) {
 	return profile, nil
 }
 
+func resolvePredefinedProfile(profileType configv1.TLSProfileType) ([]string, string, bool) {
+	predefined, ok := configv1.TLSProfiles[profileType]
+	if !ok {
+		return nil, "", false
+	}
+	return predefined.Ciphers, string(predefined.MinTLSVersion), true
+}
+
 func (c *Client) getIngressControllerTLS(fallback *APIServerTLSProfile) (*IngressTLSProfile, error) {
 	ingress, err := c.operatorClient.OperatorV1().IngressControllers("openshift-ingress-operator").Get(context.Background(), "default", metav1.GetOptions{})
 	if err != nil {
@@ -76,17 +84,9 @@ func (c *Client) getIngressControllerTLS(fallback *APIServerTLSProfile) (*Ingres
 		profile.MinTLSVersion = string(custom.MinTLSVersion)
 		return profile, nil
 	}
-	if ingress.Spec.TLSSecurityProfile.Type == configv1.TLSProfileOldType {
-		profile.Ciphers = configv1.TLSProfiles[configv1.TLSProfileOldType].Ciphers
-		profile.MinTLSVersion = string(configv1.TLSProfiles[configv1.TLSProfileOldType].MinTLSVersion)
-	}
-	if ingress.Spec.TLSSecurityProfile.Type == configv1.TLSProfileIntermediateType {
-		profile.Ciphers = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers
-		profile.MinTLSVersion = string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion)
-	}
-	if ingress.Spec.TLSSecurityProfile.Type == configv1.TLSProfileModernType {
-		profile.Ciphers = configv1.TLSProfiles[configv1.TLSProfileModernType].Ciphers
-		profile.MinTLSVersion = string(configv1.TLSProfiles[configv1.TLSProfileModernType].MinTLSVersion)
+	if ciphers, minVer, ok := resolvePredefinedProfile(ingress.Spec.TLSSecurityProfile.Type); ok {
+		profile.Ciphers = ciphers
+		profile.MinTLSVersion = minVer
 	}
 
 	return profile, nil
@@ -106,18 +106,11 @@ func extractAPIServerTLS(apiserver *configv1.APIServer) *APIServerTLSProfile {
 	if custom := apiserver.Spec.TLSSecurityProfile.Custom; custom != nil {
 		profile.Ciphers = custom.Ciphers
 		profile.MinTLSVersion = string(custom.MinTLSVersion)
+		return profile
 	}
-	if apiserver.Spec.TLSSecurityProfile.Type == configv1.TLSProfileOldType {
-		profile.Ciphers = configv1.TLSProfiles[configv1.TLSProfileOldType].Ciphers
-		profile.MinTLSVersion = string(configv1.TLSProfiles[configv1.TLSProfileOldType].MinTLSVersion)
-	}
-	if apiserver.Spec.TLSSecurityProfile.Type == configv1.TLSProfileIntermediateType {
-		profile.Ciphers = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers
-		profile.MinTLSVersion = string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion)
-	}
-	if apiserver.Spec.TLSSecurityProfile.Type == configv1.TLSProfileModernType {
-		profile.Ciphers = configv1.TLSProfiles[configv1.TLSProfileModernType].Ciphers
-		profile.MinTLSVersion = string(configv1.TLSProfiles[configv1.TLSProfileModernType].MinTLSVersion)
+	if ciphers, minVer, ok := resolvePredefinedProfile(apiserver.Spec.TLSSecurityProfile.Type); ok {
+		profile.Ciphers = ciphers
+		profile.MinTLSVersion = minVer
 	}
 
 	return profile
@@ -139,11 +132,9 @@ func (c *Client) getKubeletTLS(fallback *APIServerTLSProfile) (*KubeletTLSProfil
 					profile.TLSCipherSuites = custom.Ciphers
 					profile.MinTLSVersion = string(custom.MinTLSVersion)
 				}
-			} else if tlsProfile.Type != "" {
-				if predefined, ok := configv1.TLSProfiles[tlsProfile.Type]; ok {
-					profile.TLSCipherSuites = predefined.Ciphers
-					profile.MinTLSVersion = string(predefined.MinTLSVersion)
-				}
+			} else if ciphers, minVer, ok := resolvePredefinedProfile(tlsProfile.Type); ok {
+				profile.TLSCipherSuites = ciphers
+				profile.MinTLSVersion = minVer
 			}
 			return profile, nil
 		}


### PR DESCRIPTION
## Summary

- Extract `resolvePredefinedProfile()` helper that uses a single `configv1.TLSProfiles` map lookup to resolve Old/Intermediate/Modern profile types into ciphers and minTLSVersion
- Replace three repeated if-blocks in `getIngressControllerTLS()` and `extractAPIServerTLS()` with calls to the new helper
- Update `getKubeletTLS()` to use the same helper for consistency (it already used a map lookup but inline)
- Fix subtle fall-through in `extractAPIServerTLS()` where Custom profile values could theoretically be overwritten by a subsequent predefined profile match — added early return

Net: -27/+18 lines in `internal/k8s/tls.go`.

## Jira

[CNF-25075](https://issues.redhat.com/browse/CNF-25075) (under [CNF-23701](https://issues.redhat.com/browse/CNF-23701) tls-scanner tuning epic)