### PR TITLE
Read HyperShift TLS profile from HostedCluster for HCP scans

### DIFF
--- a/cmd/tls-scanner/main.go
+++ b/cmd/tls-scanner/main.go
@@ -75,6 +75,8 @@ func run(args []string) (exitCode int) {
 	scanTimeoutPerTarget := fs.Int("scan-timeout-per-target", scanner.DefaultScanTimeouts.PerTargetSeconds, "Seconds per target for batch scan timeout calculation")
 	connectTimeout := fs.Int("connect-timeout", scanner.DefaultScanTimeouts.ConnectTimeout, "Timeout in seconds for testssl.sh connect and openssl operations")
 	tlsProfileType := fs.String("tls-profile-type", "", "Expected cluster TLS profile type for compliance checks (Old, Intermediate, Modern). When set, skips reading APIServer/cluster from the API.")
+	hypershiftHostedClusterName := fs.String("hypershift-hosted-cluster-name", "", "HyperShift HostedCluster name. When set, TLS config is read from HostedCluster.spec.configuration on the management cluster instead of APIServer/cluster.")
+	hypershiftHostedClusterNamespace := fs.String("hypershift-hosted-cluster-namespace", "clusters", "Namespace of the HyperShift HostedCluster CR.")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -133,8 +135,23 @@ func run(args []string) (exitCode int) {
 		return 1
 	}
 
+	var client *k8s.Client
 	var tlsProfileOverride *k8s.TLSSecurityProfile
-	if *tlsProfileType != "" {
+	if *hypershiftHostedClusterName != "" && *tlsProfileType != "" {
+		slog.Warn("both --hypershift-hosted-cluster-name and --tls-profile-type are set; using HostedCluster TLS config")
+	}
+	if *hypershiftHostedClusterName != "" {
+		client, err = k8s.NewClient()
+		if err != nil {
+			slog.Error("could not create kubernetes client for HyperShift HostedCluster lookup", "error", err)
+			return 1
+		}
+		tlsProfileOverride, err = client.GetTLSSecurityProfileFromHostedCluster(*hypershiftHostedClusterName, *hypershiftHostedClusterNamespace)
+		if err != nil {
+			slog.Error("could not load TLS profile from HostedCluster", "error", err)
+			return 1
+		}
+	} else if *tlsProfileType != "" {
 		tlsProfileOverride, err = k8s.NewTLSSecurityProfileFromType(*tlsProfileType)
 		if err != nil {
 			slog.Error("invalid tls profile type", "error", err)
@@ -166,7 +183,6 @@ func run(args []string) (exitCode int) {
 		return 1
 	}
 
-	var client *k8s.Client
 	var pods []k8s.PodInfo
 
 	if *targets != "" {
@@ -236,10 +252,12 @@ func run(args []string) (exitCode int) {
 	}
 
 	if *allPods {
-		client, err = k8s.NewClient()
-		if err != nil {
-			slog.Error("could not create kubernetes client for --all-pods", "error", err)
-			return 1
+		if client == nil {
+			client, err = k8s.NewClient()
+			if err != nil {
+				slog.Error("could not create kubernetes client for --all-pods", "error", err)
+				return 1
+			}
 		}
 
 		pods, err = client.GetAllPodsInfo()

--- a/internal/k8s/hypershift.go
+++ b/internal/k8s/hypershift.go
@@ -1,0 +1,101 @@
+package k8s
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const defaultHostedClusterNamespace = "clusters"
+
+var hostedClusterGVR = schema.GroupVersionResource{
+	Group:    "hypershift.openshift.io",
+	Version:  "v1beta1",
+	Resource: "hostedclusters",
+}
+
+// GetTLSSecurityProfileFromHostedCluster loads the expected TLS profile from a
+// HyperShift HostedCluster on the management cluster. HCP workloads (kube-apiserver,
+// etcd, oauth-openshift) run on the management cluster but inherit TLS settings
+// from HostedCluster.spec.configuration, not from the management APIServer CR.
+func (c *Client) GetTLSSecurityProfileFromHostedCluster(name, namespace string) (*TLSSecurityProfile, error) {
+	if namespace == "" {
+		namespace = defaultHostedClusterNamespace
+	}
+
+	slog.Info("loading TLS security profile from HostedCluster", "name", name, "namespace", namespace)
+
+	obj, err := c.dynamicClient.Resource(hostedClusterGVR).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("get HostedCluster %s/%s: %w", namespace, name, err)
+	}
+
+	apiServerSpec, err := extractHostedClusterAPIServerSpec(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	profile := TLSSecurityProfileFromAPIServerSpec(apiServerSpec)
+	if profile.APIServer != nil {
+		slog.Info("loaded TLS profile from HostedCluster",
+			"name", name,
+			"namespace", namespace,
+			"type", profile.APIServer.Type,
+			"minTLSVersion", profile.APIServer.MinTLSVersion,
+		)
+	}
+
+	return profile, nil
+}
+
+func extractHostedClusterAPIServerSpec(obj *unstructured.Unstructured) (*configv1.APIServerSpec, error) {
+	raw, found, err := unstructured.NestedMap(obj.Object, "spec", "configuration", "apiServer")
+	if err != nil {
+		return nil, fmt.Errorf("read HostedCluster configuration.apiServer: %w", err)
+	}
+	if !found || len(raw) == 0 {
+		slog.Warn("HostedCluster has no configuration.apiServer; using default TLS profile")
+		return &configv1.APIServerSpec{}, nil
+	}
+
+	data, err := json.Marshal(raw)
+	if err != nil {
+		return nil, fmt.Errorf("marshal HostedCluster configuration.apiServer: %w", err)
+	}
+
+	spec := &configv1.APIServerSpec{}
+	if err := json.Unmarshal(data, spec); err != nil {
+		return nil, fmt.Errorf("unmarshal HostedCluster configuration.apiServer: %w", err)
+	}
+
+	return spec, nil
+}
+
+// TLSSecurityProfileFromAPIServerSpec builds a cluster TLS profile from an
+// APIServerSpec, propagating the APIServer profile to ingress and kubelet the
+// same way standalone OpenShift does when no component override exists.
+func TLSSecurityProfileFromAPIServerSpec(spec *configv1.APIServerSpec) *TLSSecurityProfile {
+	if spec == nil {
+		spec = &configv1.APIServerSpec{}
+	}
+
+	apiServer := extractAPIServerTLSFromSpec(spec)
+	return &TLSSecurityProfile{
+		APIServer: apiServer,
+		IngressController: &IngressTLSProfile{
+			Type:          apiServer.Type,
+			Ciphers:       apiServer.Ciphers,
+			MinTLSVersion: apiServer.MinTLSVersion,
+		},
+		KubeletConfig: &KubeletTLSProfile{
+			TLSCipherSuites: apiServer.Ciphers,
+			MinTLSVersion:   apiServer.MinTLSVersion,
+		},
+	}
+}

--- a/internal/k8s/hypershift_test.go
+++ b/internal/k8s/hypershift_test.go
@@ -1,0 +1,110 @@
+package k8s
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestTLSSecurityProfileFromAPIServerSpec(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		spec            *configv1.APIServerSpec
+		wantType        string
+		wantMinTLS      string
+		wantIngressType string
+	}{
+		{
+			name:            "nil spec uses default",
+			spec:            nil,
+			wantType:        "Default",
+			wantIngressType: "Default",
+		},
+		{
+			name: "modern profile",
+			spec: &configv1.APIServerSpec{
+				TLSSecurityProfile: &configv1.TLSSecurityProfile{
+					Type: configv1.TLSProfileModernType,
+				},
+			},
+			wantType:        "Modern",
+			wantMinTLS:      string(configv1.TLSProfiles[configv1.TLSProfileModernType].MinTLSVersion),
+			wantIngressType: "Modern",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := TLSSecurityProfileFromAPIServerSpec(tt.spec)
+			if got.APIServer.Type != tt.wantType {
+				t.Errorf("APIServer.Type = %q, want %q", got.APIServer.Type, tt.wantType)
+			}
+			if got.IngressController.Type != tt.wantIngressType {
+				t.Errorf("IngressController.Type = %q, want %q", got.IngressController.Type, tt.wantIngressType)
+			}
+			if tt.wantMinTLS != "" && got.APIServer.MinTLSVersion != tt.wantMinTLS {
+				t.Errorf("APIServer.MinTLSVersion = %q, want %q", got.APIServer.MinTLSVersion, tt.wantMinTLS)
+			}
+		})
+	}
+}
+
+func TestExtractHostedClusterAPIServerSpec(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		object      map[string]any
+		wantType    string
+		wantDefault bool
+	}{
+		{
+			name:        "missing configuration uses default",
+			object:      map[string]any{"spec": map[string]any{}},
+			wantDefault: true,
+		},
+		{
+			name: "modern hosted cluster configuration",
+			object: map[string]any{
+				"spec": map[string]any{
+					"configuration": map[string]any{
+						"apiServer": map[string]any{
+							"tlsSecurityProfile": map[string]any{
+								"type":   "Modern",
+								"modern": map[string]any{},
+							},
+						},
+					},
+				},
+			},
+			wantType: "Modern",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec, err := extractHostedClusterAPIServerSpec(&unstructured.Unstructured{Object: tt.object})
+			if err != nil {
+				t.Fatalf("extractHostedClusterAPIServerSpec() error = %v", err)
+			}
+
+			profile := TLSSecurityProfileFromAPIServerSpec(spec)
+			if tt.wantDefault {
+				if profile.APIServer.Type != "Default" {
+					t.Errorf("APIServer.Type = %q, want Default", profile.APIServer.Type)
+				}
+				return
+			}
+			if profile.APIServer.Type != tt.wantType {
+				t.Errorf("APIServer.Type = %q, want %q", profile.APIServer.Type, tt.wantType)
+			}
+		})
+	}
+}

--- a/internal/k8s/tls.go
+++ b/internal/k8s/tls.go
@@ -29,7 +29,7 @@ func (c *Client) GetTLSSecurityProfile() (*TLSSecurityProfile, error) {
 		slog.Warn("could not get API Server custom resource", "error", err)
 		profile.TLSAdherence = configv1.TLSAdherencePolicyNoOpinion
 	} else {
-		profile.APIServer = extractAPIServerTLS(apiserver)
+		profile.APIServer = extractAPIServerTLSFromSpec(&apiserver.Spec)
 		profile.TLSAdherence = apiserver.Spec.TLSAdherence
 	}
 
@@ -93,29 +93,33 @@ func (c *Client) getIngressControllerTLS(fallback *APIServerTLSProfile) (*Ingres
 }
 
 func extractAPIServerTLS(apiserver *configv1.APIServer) *APIServerTLSProfile {
+	return extractAPIServerTLSFromSpec(&apiserver.Spec)
+}
+
+func extractAPIServerTLSFromSpec(spec *configv1.APIServerSpec) *APIServerTLSProfile {
 	profile := &APIServerTLSProfile{}
 
-	if apiserver.Spec.TLSSecurityProfile == nil {
+	if spec == nil || spec.TLSSecurityProfile == nil {
 		profile.Type = defaultProfileName
 		profile.Ciphers = defaultProfileCiphers
 		profile.MinTLSVersion = defaultProfileMinVer
 		return profile
 	}
 
-	profile.Type = string(apiserver.Spec.TLSSecurityProfile.Type)
-	if custom := apiserver.Spec.TLSSecurityProfile.Custom; custom != nil {
+	profile.Type = string(spec.TLSSecurityProfile.Type)
+	if custom := spec.TLSSecurityProfile.Custom; custom != nil {
 		profile.Ciphers = custom.Ciphers
 		profile.MinTLSVersion = string(custom.MinTLSVersion)
 	}
-	if apiserver.Spec.TLSSecurityProfile.Type == configv1.TLSProfileOldType {
+	if spec.TLSSecurityProfile.Type == configv1.TLSProfileOldType {
 		profile.Ciphers = configv1.TLSProfiles[configv1.TLSProfileOldType].Ciphers
 		profile.MinTLSVersion = string(configv1.TLSProfiles[configv1.TLSProfileOldType].MinTLSVersion)
 	}
-	if apiserver.Spec.TLSSecurityProfile.Type == configv1.TLSProfileIntermediateType {
+	if spec.TLSSecurityProfile.Type == configv1.TLSProfileIntermediateType {
 		profile.Ciphers = configv1.TLSProfiles[configv1.TLSProfileIntermediateType].Ciphers
 		profile.MinTLSVersion = string(configv1.TLSProfiles[configv1.TLSProfileIntermediateType].MinTLSVersion)
 	}
-	if apiserver.Spec.TLSSecurityProfile.Type == configv1.TLSProfileModernType {
+	if spec.TLSSecurityProfile.Type == configv1.TLSProfileModernType {
 		profile.Ciphers = configv1.TLSProfiles[configv1.TLSProfileModernType].Ciphers
 		profile.MinTLSVersion = string(configv1.TLSProfiles[configv1.TLSProfileModernType].MinTLSVersion)
 	}


### PR DESCRIPTION
When scanning hosted control plane workloads on a management cluster, load the expected TLS profile from HostedCluster.spec.configuration instead of the management cluster APIServer CR. Adds --hypershift-hosted-cluster-name and --hypershift-hosted-cluster-namespace flags for this path.