### PR TITLE
ROX-34354: Add STARTTLS protocol support

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ The scanner binary accepts the following command-line options. These are configu
 - `-junit-file <file>` - Output results in JUnit XML format to specified file
 - `-log-file <file>` - Redirect all log output to the specified file
 - `-timing-file <file>` - Write timing report to specified file in artifact-dir
+- `-starttls-ports <mapping>` - Enable STARTTLS for specific ports (e.g., `postgres=5432:6432,mysql=3306`). Comma separates protocols, colon separates multiple ports within a protocol. Supported protocols: `ftp`, `smtp`, `lmtp`, `pop3`, `imap`, `xmpp`, `xmpp-server`, `telnet`, `ldap`, `nntp`, `sieve`, `postgres`, `mysql`
 - `-version` - Print version and exit
 
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ The scanner binary accepts the following command-line options. These are configu
 - `-junit-file <file>` - Output results in JUnit XML format to specified file
 - `-log-file <file>` - Redirect all log output to the specified file
 - `-timing-file <file>` - Write timing report to specified file in artifact-dir
-- `-starttls-ports <mapping>` - Enable STARTTLS for specific ports (e.g., `postgres=5432:6432,mysql=3306`). Comma separates protocols, colon separates multiple ports within a protocol. Supported protocols: `ftp`, `smtp`, `lmtp`, `pop3`, `imap`, `xmpp`, `xmpp-server`, `telnet`, `ldap`, `nntp`, `sieve`, `postgres`, `mysql`
+- `-starttls-ports <mapping>` - Enable STARTTLS for specific ports (e.g., `postgres=5432:6432,mysql=3306`). Comma separates protocols, colon separates multiple ports within a protocol. Supported protocols: `ftp`, `smtp`, `lmtp`, `pop3`, `imap`, `xmpp`, `xmpp-server`, `telnet`, `ldap`, `nntp`, `sieve`, `postgres`, `mysql`. **Auto-detection:** When process names are available from `/proc` discovery (e.g., `postgres`, `mysqld`), STARTTLS is used automatically without needing this flag. Explicit `--starttls-ports` mappings take priority over auto-detection.
 - `-version` - Print version and exit
 
 

--- a/cmd/tls-scanner/main.go
+++ b/cmd/tls-scanner/main.go
@@ -75,6 +75,7 @@ func run(args []string) (exitCode int) {
 	scanTimeoutPerTarget := fs.Int("scan-timeout-per-target", scanner.DefaultScanTimeouts.PerTargetSeconds, "Seconds per target for batch scan timeout calculation")
 	connectTimeout := fs.Int("connect-timeout", scanner.DefaultScanTimeouts.ConnectTimeout, "Timeout in seconds for testssl.sh connect and openssl operations")
 	tlsProfileType := fs.String("tls-profile-type", "", "Expected cluster TLS profile type for compliance checks (Old, Intermediate, Modern). When set, skips reading APIServer/cluster from the API.")
+	starttlsPortsFlag := fs.String("starttls-ports", "", "STARTTLS protocol-to-port mapping (e.g., postgres=5432:6432,mysql=3306)")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -125,6 +126,12 @@ func run(args []string) (exitCode int) {
 	timeouts := scanner.ScanTimeouts{
 		PerTargetSeconds: *scanTimeoutPerTarget,
 		ConnectTimeout:   *connectTimeout,
+	}
+
+	starttlsPorts, err := scanner.ParseStarttlsPorts(*starttlsPortsFlag)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return 2
 	}
 
 	policy, err := scanner.Policy()
@@ -196,7 +203,7 @@ func run(args []string) (exitCode int) {
 			return 0
 		}
 
-		scanResults := scanner.Scan(jobs, *concurrentScans, nil, tlsProfileOverride, policy, timeouts)
+		scanResults := scanner.Scan(jobs, *concurrentScans, nil, tlsProfileOverride, policy, timeouts, starttlsPorts)
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
@@ -219,7 +226,7 @@ func run(args []string) (exitCode int) {
 			return 1
 		}
 
-		scanResults := scanner.Scan(jobs, *concurrentScans, nil, tlsProfileOverride, policy, timeouts)
+		scanResults := scanner.Scan(jobs, *concurrentScans, nil, tlsProfileOverride, policy, timeouts, starttlsPorts)
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
@@ -282,7 +289,7 @@ func run(args []string) (exitCode int) {
 	}
 
 	if len(pods) > 0 {
-		scanResults := scanner.PerformClusterScan(pods, *concurrentScans, client, policy, timeouts, tlsProfileOverride)
+		scanResults := scanner.PerformClusterScan(pods, *concurrentScans, client, policy, timeouts, tlsProfileOverride, starttlsPorts)
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
@@ -311,7 +318,7 @@ func run(args []string) (exitCode int) {
 		return 0
 	}
 
-	scanResults := scanner.Scan(jobs, *concurrentScans, client, tlsProfileOverride, policy, timeouts)
+	scanResults := scanner.Scan(jobs, *concurrentScans, client, tlsProfileOverride, policy, timeouts, starttlsPorts)
 	finalScanResults = &scanResults
 
 	if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {

--- a/deploy.sh
+++ b/deploy.sh
@@ -22,6 +22,7 @@
 #   SCANNER_PARALLEL - Parallel scan count (default: 4)
 #   ARTIFACT_WAIT    - Seconds to keep pod alive after scan for artifact collection (default: 30, CI uses 300)
 #   TLS_TEST_TIMEOUT - Timeout for cluster stabilization during TLS tests (default: 600)
+#   STARTTLS_PORTS   - (Optional) STARTTLS protocol-to-port mapping (e.g., postgres=5432:6432,mysql=3306)
 
 # --- Configuration ---
 APP_NAME="tls-scanner"
@@ -202,11 +203,16 @@ EOF
         echo "--> Limiting scan to first ${LIMIT_IPS} IPs (testing mode)"
     fi
 
+    STARTTLS_PORTS_ARG=""
+    if [ -n "$STARTTLS_PORTS" ]; then
+        STARTTLS_PORTS_ARG="--starttls-ports $(echo "${STARTTLS_PORTS}" | tr -d ' ')"
+    fi
+
     SCANNER_CPU="${SCANNER_CPU:-4}"
     SCANNER_MEM="${SCANNER_MEM:-4Gi}"
     SCANNER_PARALLEL="${SCANNER_PARALLEL:-4}"
     ARTIFACT_WAIT="${ARTIFACT_WAIT:-30}"
-    sed -e "s|\\\${SCANNER_IMAGE}|${SCANNER_IMAGE}|g" -e "s|\\\${NAMESPACE}|${NAMESPACE}|g" -e "s|\\\${JOB_NAME}|${JOB_NAME}|g" -e "s|\\\${NAMESPACE_FILTER_ARG}|${NAMESPACE_FILTER_ARG}|g" -e "s|\\\${LIMIT_IPS_ARG}|${LIMIT_IPS_ARG}|g" -e "s|\\\${SCANNER_CPU:-4}|${SCANNER_CPU}|g" -e "s|\\\${SCANNER_MEM:-4Gi}|${SCANNER_MEM}|g" -e "s|\\\${SCANNER_PARALLEL:-4}|${SCANNER_PARALLEL}|g" -e "s|\\\${ARTIFACT_WAIT:-300}|${ARTIFACT_WAIT}|g" "$JOB_TEMPLATE" | oc apply -f -
+    sed -e "s|\\\${SCANNER_IMAGE}|${SCANNER_IMAGE}|g" -e "s|\\\${NAMESPACE}|${NAMESPACE}|g" -e "s|\\\${JOB_NAME}|${JOB_NAME}|g" -e "s|\\\${NAMESPACE_FILTER_ARG}|${NAMESPACE_FILTER_ARG}|g" -e "s|\\\${LIMIT_IPS_ARG}|${LIMIT_IPS_ARG}|g" -e "s|\\\${STARTTLS_PORTS_ARG}|${STARTTLS_PORTS_ARG}|g" -e "s|\\\${SCANNER_CPU:-4}|${SCANNER_CPU}|g" -e "s|\\\${SCANNER_MEM:-4Gi}|${SCANNER_MEM}|g" -e "s|\\\${SCANNER_PARALLEL:-4}|${SCANNER_PARALLEL}|g" -e "s|\\\${ARTIFACT_WAIT:-300}|${ARTIFACT_WAIT}|g" "$JOB_TEMPLATE" | oc apply -f -
     check_error "Applying Job manifest"
 
     echo "--> Scanner Job '${JOB_NAME}' deployed."

--- a/internal/output/csv.go
+++ b/internal/output/csv.go
@@ -14,7 +14,7 @@ import (
 )
 
 var csvColumns = []string{
-	"IP", "Port", "Protocol", "Service", "Pod Name", "Namespace", "Component Name", "Component Maintainer",
+	"IP", "Port", "Protocol", "Service", "STARTTLS Protocol", "Pod Name", "Namespace", "Component Name", "Component Maintainer",
 	"Process", "TLS Ciphers", "TLS Version", "TLS Supported Groups", "Status", "Reason", "Listen Address",
 	"TLS 1.3 Supported", "ML-KEM Supported", "ML-KEM KEMs", "All KEMs",
 	"TLS 1.3 Offered", "TLS 1.2 Only", "PQC Capable", "Readiness Notes",
@@ -124,6 +124,7 @@ func WriteCSVOutput(results scanner.ScanResults, filename string) error {
 				"Port":                          port,
 				"Protocol":                      stringOrNA(portResult.Protocol),
 				"Service":                       stringOrNA(portResult.Service),
+				"STARTTLS Protocol":             stringOrNA(portResult.STARTTLSProtocol),
 				"Pod Name":                      podName,
 				"Namespace":                     namespace,
 				"Component Name":                componentName,

--- a/internal/output/csv_output_test.go
+++ b/internal/output/csv_output_test.go
@@ -89,8 +89,8 @@ func TestWriteCSVOutput(t *testing.T) {
 	if rows[1][0] != "10.0.0.1" || rows[1][1] != "443" {
 		t.Fatalf("unexpected ip/port values: %#v", rows[1][:2])
 	}
-	if rows[1][15] != "Yes" || rows[1][16] != "Yes" {
-		t.Fatalf("unexpected yes/no formatting for TLS13/ML-KEM: %q %q", rows[1][15], rows[1][16])
+	if rows[1][16] != "Yes" || rows[1][17] != "Yes" {
+		t.Fatalf("unexpected yes/no formatting for TLS13/ML-KEM: %q %q", rows[1][16], rows[1][17])
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -316,11 +316,22 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 	}
 
 	// Split jobs into direct-TLS and STARTTLS groups.
+	// Explicit --starttls-ports mappings take priority; otherwise fall back to
+	// process-name auto-detection (e.g. comm "postgres" → STARTTLS postgres).
 	var directJobs []ScanJob
 	starttlsGroups := make(map[string][]ScanJob)
 	for _, job := range jobs {
 		if proto := starttlsPorts[job.Port]; proto != "" {
 			starttlsGroups[proto] = append(starttlsGroups[proto], job)
+		} else if client != nil {
+			if comm, ok := client.GetProcessName(job.IP, job.Port); ok {
+				if proto := StarttlsProtoForProcess(comm); proto != "" {
+					slog.Info("auto-detected STARTTLS protocol from process name", "ip", job.IP, "port", job.Port, "process", comm, "protocol", proto)
+					starttlsGroups[proto] = append(starttlsGroups[proto], job)
+					continue
+				}
+			}
+			directJobs = append(directJobs, job)
 		} else {
 			directJobs = append(directJobs, job)
 		}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -220,7 +220,7 @@ func DiscoverTargets(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client
 	return DiscoveryResults{ScanJobs: scanJobs, Skipped: skipped}
 }
 
-func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client, policy *ComponentPolicy, timeouts ScanTimeouts, tlsProfileOverride *k8s.TLSSecurityProfile) ScanResults {
+func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client, policy *ComponentPolicy, timeouts ScanTimeouts, tlsProfileOverride *k8s.TLSSecurityProfile, starttlsPorts StarttlsPorts) ScanResults {
 	defer timing.Timings.Track("performClusterScan", "")()
 	startTime := time.Now()
 
@@ -255,7 +255,7 @@ MAX_PARALLEL (testssl): %d
 
 	discovery := DiscoverTargets(pods, concurrentScans, client)
 
-	batchResults := batchScan(discovery.ScanJobs, concurrentScans, client, tlsConfig, policy, timeouts)
+	batchResults := batchScan(discovery.ScanJobs, concurrentScans, client, tlsConfig, policy, timeouts, starttlsPorts)
 
 	results := assembleResults(startTime, totalIPs, tlsConfig, discovery.Skipped, batchResults)
 
@@ -277,7 +277,7 @@ MAX_PARALLEL (testssl): %d
 
 // Scan runs a batch testssl.sh scan on pre-built scan jobs.
 // Used by --targets and single-host paths (no k8s discovery needed).
-func Scan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile, policy *ComponentPolicy, timeouts ScanTimeouts) ScanResults {
+func Scan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile, policy *ComponentPolicy, timeouts ScanTimeouts, starttlsPorts StarttlsPorts) ScanResults {
 	defer timing.Timings.Track("scan", "")()
 	startTime := time.Now()
 
@@ -292,7 +292,7 @@ func Scan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8
 	fmt.Printf("MAX_PARALLEL: %d\n", concurrentScans)
 	fmt.Printf("========================================\n\n")
 
-	batchResults := batchScan(jobs, concurrentScans, client, tlsConfig, policy, timeouts)
+	batchResults := batchScan(jobs, concurrentScans, client, tlsConfig, policy, timeouts, starttlsPorts)
 	results := assembleResults(startTime, 0, tlsConfig, batchResults)
 
 	duration := time.Since(startTime)
@@ -310,7 +310,7 @@ func Scan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8
 	return results
 }
 
-func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile, policy *ComponentPolicy, timeouts ScanTimeouts) []portScanResult {
+func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile, policy *ComponentPolicy, timeouts ScanTimeouts, starttlsPorts StarttlsPorts) []portScanResult {
 	if len(jobs) == 0 {
 		return nil
 	}
@@ -319,7 +319,7 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 	var directJobs []ScanJob
 	starttlsGroups := make(map[string][]ScanJob)
 	for _, job := range jobs {
-		if proto := starttlsProtocol(job.Port); proto != "" {
+		if proto := starttlsPorts[job.Port]; proto != "" {
 			starttlsGroups[proto] = append(starttlsGroups[proto], job)
 		} else {
 			directJobs = append(directJobs, job)
@@ -669,17 +669,6 @@ func writeTargetsFile(targets []string) (string, error) {
 	}
 	f.Close()
 	return f.Name(), nil
-}
-
-// starttlsProtocol returns the testssl.sh --starttls protocol name for a port,
-// or "" if the port uses direct TLS.
-func starttlsProtocol(port int) string {
-	switch port {
-	case 5432:
-		return "postgres"
-	default:
-		return ""
-	}
 }
 
 func targetKey(host, port string) string {

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -315,6 +315,29 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 		return nil
 	}
 
+	// Split jobs into direct-TLS and STARTTLS groups.
+	var directJobs []ScanJob
+	starttlsGroups := make(map[string][]ScanJob)
+	for _, job := range jobs {
+		if proto := starttlsProtocol(job.Port); proto != "" {
+			starttlsGroups[proto] = append(starttlsGroups[proto], job)
+		} else {
+			directJobs = append(directJobs, job)
+		}
+	}
+
+	var results []portScanResult
+	if len(directJobs) > 0 {
+		results = append(results, scanBatchGroup(directJobs, concurrentScans, "", client, tlsConfig, policy, timeouts)...)
+	}
+	for proto, protoJobs := range starttlsGroups {
+		results = append(results, scanBatchGroup(protoJobs, concurrentScans, proto, client, tlsConfig, policy, timeouts)...)
+	}
+
+	return results
+}
+
+func scanBatchGroup(jobs []ScanJob, concurrentScans int, starttls string, client *k8s.Client, tlsConfig *k8s.TLSSecurityProfile, policy *ComponentPolicy, timeouts ScanTimeouts) []portScanResult {
 	jobIndex := make(map[string]ScanJob, len(jobs))
 	targets := make([]string, 0, len(jobs))
 	for _, job := range jobs {
@@ -339,7 +362,11 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 	outputFile.Close()
 	defer os.Remove(outputFileName)
 
-	slog.Info("running testssl.sh batch scan", "targets", len(targets), "maxParallel", concurrentScans)
+	label := "testssl.sh[batch]"
+	if starttls != "" {
+		label = fmt.Sprintf("testssl.sh[batch-starttls-%s]", starttls)
+	}
+	slog.Info("running batch scan", "label", label, "targets", len(targets), "maxParallel", concurrentScans)
 	perTarget := time.Duration(timeouts.PerTargetSeconds) * time.Second
 	timeout := perTarget*time.Duration(len(targets)) + 2*time.Minute
 	slog.Debug("batch timeout set", "timeout", timeout)
@@ -347,33 +374,37 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 	defer cancel()
 
 	connectTimeoutStr := strconv.Itoa(timeouts.ConnectTimeout)
-	cmd := exec.CommandContext(ctx, "testssl.sh", "-p", "-s", "-f", "-E",
+	args := []string{"-p", "-s", "-f", "-E",
 		"--connect-timeout", connectTimeoutStr,
 		"--openssl-timeout", connectTimeoutStr,
 		"--file", targetsFile,
 		"--jsonfile", outputFileName,
 		"--warnings", "off",
 		"--color", "0",
-		"--parallel")
+		"--parallel"}
+	if starttls != "" {
+		args = append(args, "--starttls", starttls)
+	}
+	cmd := exec.CommandContext(ctx, "testssl.sh", args...)
 	cmd.Env = append(os.Environ(), fmt.Sprintf("MAX_PARALLEL=%d", concurrentScans))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
-	stop := timing.Timings.Track("testssl.sh[batch]", fmt.Sprintf("%d targets", len(targets)))
+	stop := timing.Timings.Track(label, fmt.Sprintf("%d targets", len(targets)))
 	cmdErr := cmd.Run()
 	stop()
 
 	if cmdErr != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			slog.Error("testssl.sh batch timed out, partial results may be available", "timeout", timeout, "targets", len(targets))
+			slog.Error("batch scan timed out, partial results may be available", "label", label, "timeout", timeout, "targets", len(targets))
 		} else {
-			slog.Warn("testssl.sh batch exited non-zero", "error", cmdErr)
+			slog.Warn("batch scan exited non-zero", "label", label, "error", cmdErr)
 		}
 	}
 
 	jsonData, readErr := os.ReadFile(outputFileName)
 	if readErr != nil || len(jsonData) == 0 {
-		slog.Error("testssl.sh batch produced no output", "error", readErr)
+		slog.Error("batch scan produced no output", "label", label, "error", readErr)
 		return nil
 	}
 
@@ -397,10 +428,11 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 		scanResult := ParseTestSSLOutput(portData, job.IP, strconv.Itoa(job.Port))
 
 		portResult := PortResult{
-			Port:     job.Port,
-			Protocol: "tcp",
-			State:    "open",
-			Service:  "ssl/tls",
+			Port:             job.Port,
+			Protocol:         "tcp",
+			State:            "open",
+			Service:          "ssl/tls",
+			STARTTLSProtocol: starttls,
 		}
 
 		portResult.TlsVersions = ExtractTLSInfo(scanResult)
@@ -450,11 +482,12 @@ func batchScan(jobs []ScanJob, concurrentScans int, client *k8s.Client, tlsConfi
 		results = append(results, portScanResult{
 			ip: job.IP, pod: job.Pod, component: job.Component,
 			result: PortResult{
-				Port:     job.Port,
-				Protocol: "tcp",
-				State:    "open",
-				Status:   StatusNoTLS,
-				Reason:   "No TLS data returned from batch scan",
+				Port:             job.Port,
+				Protocol:         "tcp",
+				State:            "open",
+				Status:           StatusNoTLS,
+				Reason:           "No TLS data returned from batch scan",
+				STARTTLSProtocol: starttls,
 			},
 		})
 	}
@@ -636,6 +669,17 @@ func writeTargetsFile(targets []string) (string, error) {
 	}
 	f.Close()
 	return f.Name(), nil
+}
+
+// starttlsProtocol returns the testssl.sh --starttls protocol name for a port,
+// or "" if the port uses direct TLS.
+func starttlsProtocol(port int) string {
+	switch port {
+	case 5432:
+		return "postgres"
+	default:
+		return ""
+	}
 }
 
 func targetKey(host, port string) string {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -34,6 +34,55 @@ func makePod(name, namespace, ip string, ports ...int32) k8s.PodInfo {
 	}
 }
 
+func TestBatchScanStarttlsRouting(t *testing.T) {
+	testutil.InstallMockTestSSL(t)
+
+	jobs := []ScanJob{
+		{IP: "10.0.0.1", Port: 443},
+		{IP: "10.0.0.2", Port: 5432},
+		{IP: "10.0.0.3", Port: 8443},
+		{IP: "10.0.0.4", Port: 3306},
+	}
+	starttlsPorts := StarttlsPorts{5432: "postgres", 3306: "mysql"}
+
+	results := batchScan(jobs, 4, nil, nil, testPolicy(t), DefaultScanTimeouts, starttlsPorts)
+
+	if len(results) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(results))
+	}
+
+	resultByIP := map[string]portScanResult{}
+	for _, r := range results {
+		resultByIP[r.ip] = r
+	}
+
+	for _, tc := range []struct {
+		ip            string
+		wantSTARTTLS  string
+		wantPort      int
+	}{
+		{"10.0.0.1", "", 443},
+		{"10.0.0.2", "postgres", 5432},
+		{"10.0.0.3", "", 8443},
+		{"10.0.0.4", "mysql", 3306},
+	} {
+		r, ok := resultByIP[tc.ip]
+		if !ok {
+			t.Errorf("missing result for %s", tc.ip)
+			continue
+		}
+		if r.result.STARTTLSProtocol != tc.wantSTARTTLS {
+			t.Errorf("%s: STARTTLSProtocol = %q, want %q", tc.ip, r.result.STARTTLSProtocol, tc.wantSTARTTLS)
+		}
+		if r.result.Port != tc.wantPort {
+			t.Errorf("%s: Port = %d, want %d", tc.ip, r.result.Port, tc.wantPort)
+		}
+		if r.result.Status != StatusOK {
+			t.Errorf("%s: Status = %s, want OK", tc.ip, r.result.Status)
+		}
+	}
+}
+
 func TestScanWithMockTestSSL(t *testing.T) {
 	testutil.InstallMockTestSSL(t)
 
@@ -41,7 +90,7 @@ func TestScanWithMockTestSSL(t *testing.T) {
 		{IP: "10.0.0.1", Port: 443},
 		{IP: "10.0.0.2", Port: 8443},
 	}
-	results := Scan(jobs, 2, nil, nil, testPolicy(t), DefaultScanTimeouts)
+	results := Scan(jobs, 2, nil, nil, testPolicy(t), DefaultScanTimeouts, nil)
 
 	if results.ScannedIPs != 2 {
 		t.Fatalf("expected 2 scanned IPs, got %d", results.ScannedIPs)
@@ -65,7 +114,7 @@ func TestScanPQCEnrichment(t *testing.T) {
 	testutil.InstallMockTestSSL(t)
 
 	jobs := []ScanJob{{IP: "10.0.0.1", Port: 443}}
-	results := Scan(jobs, 1, nil, nil, testPolicy(t), DefaultScanTimeouts)
+	results := Scan(jobs, 1, nil, nil, testPolicy(t), DefaultScanTimeouts, nil)
 
 	pr := results.IPResults[0].PortResults[0]
 
@@ -98,7 +147,7 @@ func TestPerformClusterScanWithMockPods(t *testing.T) {
 		makePod("no-ports", "openshift-console", "10.128.0.30"),
 	}
 
-	results := PerformClusterScan(pods, 2, nil, testPolicy(t), DefaultScanTimeouts, nil)
+	results := PerformClusterScan(pods, 2, nil, testPolicy(t), DefaultScanTimeouts, nil, nil)
 
 	if results.ScannedIPs != 3 {
 		t.Errorf("expected 3 scanned IPs (including no-ports), got %d", results.ScannedIPs)

--- a/internal/scanner/starttls.go
+++ b/internal/scanner/starttls.go
@@ -25,6 +25,15 @@ var knownStarttlsProtocols = map[string]bool{
 	"mysql":       true,
 }
 
+var commToStarttls = map[string]string{
+	"postgres": "postgres",
+	"mysqld":   "mysql",
+}
+
+func StarttlsProtoForProcess(comm string) string {
+	return commToStarttls[comm]
+}
+
 // ParseStarttlsPorts parses a --starttls-ports flag value into a StarttlsPorts
 // map. The format is: protocol=port[:port...][,protocol=port[:port...]]
 // Example: postgres=5432:6432,mysql=3306

--- a/internal/scanner/starttls.go
+++ b/internal/scanner/starttls.go
@@ -1,0 +1,73 @@
+package scanner
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+// knownStarttlsProtocols lists the STARTTLS protocol names that testssl.sh
+// supports via --starttls.
+var knownStarttlsProtocols = map[string]bool{
+	"ftp":         true,
+	"smtp":        true,
+	"lmtp":        true,
+	"pop3":        true,
+	"imap":        true,
+	"xmpp":        true,
+	"xmpp-server": true,
+	"telnet":      true,
+	"ldap":        true,
+	"nntp":        true,
+	"sieve":       true,
+	"postgres":    true,
+	"mysql":       true,
+}
+
+// ParseStarttlsPorts parses a --starttls-ports flag value into a StarttlsPorts
+// map. The format is: protocol=port[:port...][,protocol=port[:port...]]
+// Example: postgres=5432:6432,mysql=3306
+func ParseStarttlsPorts(value string) (StarttlsPorts, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil, nil
+	}
+
+	result := make(StarttlsPorts)
+	for _, entry := range strings.Split(value, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+			return nil, fmt.Errorf("invalid starttls-ports entry %q: expected protocol=port[:port]", entry)
+		}
+
+		proto := strings.TrimSpace(parts[0])
+		if !knownStarttlsProtocols[proto] {
+			known := make([]string, 0, len(knownStarttlsProtocols))
+			for k := range knownStarttlsProtocols {
+				known = append(known, k)
+			}
+			slices.Sort(known)
+			return nil, fmt.Errorf("unknown STARTTLS protocol %q (known: %s)", proto, strings.Join(known, ", "))
+		}
+
+		for _, portStr := range strings.Split(parts[1], ":") {
+			portStr = strings.TrimSpace(portStr)
+			port, err := strconv.Atoi(portStr)
+			if err != nil || port < 1 || port > 65535 {
+				return nil, fmt.Errorf("invalid port %q in starttls-ports entry %q", portStr, entry)
+			}
+			if existing, ok := result[port]; ok && existing != proto {
+				return nil, fmt.Errorf("port %d mapped to both %q and %q", port, existing, proto)
+			}
+			result[port] = proto
+		}
+	}
+
+	return result, nil
+}

--- a/internal/scanner/starttls_test.go
+++ b/internal/scanner/starttls_test.go
@@ -4,6 +4,23 @@ import (
 	"testing"
 )
 
+func TestStarttlsProtoForProcess(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		comm string
+		want string
+	}{
+		{"postgres", "postgres"},
+		{"mysqld", "mysql"},
+		{"nginx", ""},
+		{"", ""},
+	} {
+		if got := StarttlsProtoForProcess(tc.comm); got != tc.want {
+			t.Errorf("StarttlsProtoForProcess(%q) = %q, want %q", tc.comm, got, tc.want)
+		}
+	}
+}
+
 func TestParseStarttlsPorts(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/scanner/starttls_test.go
+++ b/internal/scanner/starttls_test.go
@@ -1,0 +1,110 @@
+package scanner
+
+import (
+	"testing"
+)
+
+func TestParseStarttlsPorts(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    StarttlsPorts
+		wantErr bool
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "single protocol single port",
+			input: "postgres=5432",
+			want:  StarttlsPorts{5432: "postgres"},
+		},
+		{
+			name:  "single protocol multiple ports",
+			input: "postgres=5432:6432",
+			want:  StarttlsPorts{5432: "postgres", 6432: "postgres"},
+		},
+		{
+			name:  "multiple protocols",
+			input: "postgres=5432,mysql=3306,smtp=25",
+			want:  StarttlsPorts{5432: "postgres", 3306: "mysql", 25: "smtp"},
+		},
+		{
+			name:  "multiple protocols with multiple ports",
+			input: "postgres=5432:6432,mysql=3306:3307",
+			want:  StarttlsPorts{5432: "postgres", 6432: "postgres", 3306: "mysql", 3307: "mysql"},
+		},
+		{
+			name:  "whitespace is trimmed",
+			input: " postgres = 5432 , mysql = 3306 ",
+			want:  StarttlsPorts{5432: "postgres", 3306: "mysql"},
+		},
+		{
+			name:    "unknown protocol",
+			input:   "bogus=5432",
+			wantErr: true,
+		},
+		{
+			name:    "invalid port",
+			input:   "postgres=abc",
+			wantErr: true,
+		},
+		{
+			name:    "port out of range",
+			input:   "postgres=99999",
+			wantErr: true,
+		},
+		{
+			name:    "port zero",
+			input:   "postgres=0",
+			wantErr: true,
+		},
+		{
+			name:    "missing port",
+			input:   "postgres=",
+			wantErr: true,
+		},
+		{
+			name:    "missing protocol",
+			input:   "=5432",
+			wantErr: true,
+		},
+		{
+			name:    "no equals sign",
+			input:   "postgres5432",
+			wantErr: true,
+		},
+		{
+			name:    "conflicting port mapping",
+			input:   "postgres=5432,mysql=5432",
+			wantErr: true,
+		},
+		{
+			name:  "same protocol same port is ok",
+			input: "postgres=5432,postgres=5432",
+			want:  StarttlsPorts{5432: "postgres"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseStarttlsPorts(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseStarttlsPorts(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("ParseStarttlsPorts(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+			for port, proto := range tt.want {
+				if got[port] != proto {
+					t.Errorf("ParseStarttlsPorts(%q)[%d] = %q, want %q", tt.input, port, got[port], proto)
+				}
+			}
+		})
+	}
+}

--- a/internal/scanner/testssl_integration_test.go
+++ b/internal/scanner/testssl_integration_test.go
@@ -33,7 +33,7 @@ func TestIntegrationSingleTarget(t *testing.T) {
 	jobs := []ScanJob{{IP: tgt.ip, Port: tgt.port}}
 
 	start := time.Now()
-	results := batchScan(jobs, 1, nil, nil, testPolicy(t), DefaultScanTimeouts)
+	results := batchScan(jobs, 1, nil, nil, testPolicy(t), DefaultScanTimeouts, nil)
 	elapsed := time.Since(start)
 
 	t.Logf("Single target %s (%s:%d): %v", tgt.desc, tgt.ip, tgt.port, elapsed)
@@ -73,7 +73,7 @@ func TestIntegrationBatchTargets(t *testing.T) {
 	}
 
 	start := time.Now()
-	results := batchScan(jobs, 4, nil, nil, testPolicy(t), DefaultScanTimeouts)
+	results := batchScan(jobs, 4, nil, nil, testPolicy(t), DefaultScanTimeouts, nil)
 	elapsed := time.Since(start)
 
 	t.Logf("Batch %d targets (MAX_PARALLEL=4): %v (%.1fs/target)",
@@ -102,12 +102,12 @@ func TestIntegrationParallelScaling(t *testing.T) {
 
 	t.Log("--- Sequential run (MAX_PARALLEL=1) ---")
 	start := time.Now()
-	seqResults := batchScan(jobs, 1, nil, nil, testPolicy(t), DefaultScanTimeouts)
+	seqResults := batchScan(jobs, 1, nil, nil, testPolicy(t), DefaultScanTimeouts, nil)
 	sequential := time.Since(start)
 
 	t.Log("--- Parallel run (MAX_PARALLEL=", len(jobs), ") ---")
 	start = time.Now()
-	parResults := batchScan(jobs, len(jobs), nil, nil, testPolicy(t), DefaultScanTimeouts)
+	parResults := batchScan(jobs, len(jobs), nil, nil, testPolicy(t), DefaultScanTimeouts, nil)
 	parallel := time.Since(start)
 
 	speedup := sequential.Seconds() / parallel.Seconds()

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -107,6 +107,7 @@ type PortResult struct {
 	Protocol                     string                     `json:"protocol"`
 	State                        string                     `json:"state"`
 	Service                      string                     `json:"service"`
+	STARTTLSProtocol             string                     `json:"starttls_protocol,omitempty"`
 	ProcessName                  string                     `json:"process_name,omitempty"`
 	ContainerName                string                     `json:"container_name,omitempty"`
 	TlsVersions                  []string                   `json:"tls_versions,omitempty"`

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -163,6 +163,10 @@ var DefaultScanTimeouts = ScanTimeouts{
 	ConnectTimeout:   5,
 }
 
+// StarttlsPorts maps TCP port numbers to testssl.sh STARTTLS protocol names
+// (e.g., 5432→"postgres"). Populated from the --starttls-ports CLI flag.
+type StarttlsPorts map[int]string
+
 type ScanJob struct {
 	IP        string
 	Port      int

--- a/internal/testutil/mock_testssl.go
+++ b/internal/testutil/mock_testssl.go
@@ -14,13 +14,17 @@ import (
 const MockTestSSLScript = `#!/bin/bash
 JSONFILE=""
 TARGETS_FILE=""
+STARTTLS=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --jsonfile) JSONFILE="$2"; shift 2;;
         --file) TARGETS_FILE="$2"; shift 2;;
+        --starttls) STARTTLS="$2"; shift 2;;
         *) shift;;
     esac
 done
+SERVICE="https"
+[ -n "$STARTTLS" ] && SERVICE="$STARTTLS"
 {
 printf '['
 FIRST=true
@@ -28,11 +32,11 @@ while IFS= read -r target; do
     ip="${target%%:*}"
     port="${target##*:}"
     [ "$FIRST" = true ] && FIRST=false || printf ','
-    printf '{"id":"TLS1_2","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
-    printf '{"id":"TLS1_3","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"},' "$ip" "$ip" "$port"
-    printf '{"id":"FS","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)"}' "$ip" "$ip" "$port"
+    printf '{"id":"TLS1_2","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)","service":"%s"},' "$ip" "$ip" "$port" "$SERVICE"
+    printf '{"id":"TLS1_3","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)","service":"%s"},' "$ip" "$ip" "$port" "$SERVICE"
+    printf '{"id":"FS","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)","service":"%s"}' "$ip" "$ip" "$port" "$SERVICE"
     if [ -z "${MOCK_NO_MLKEM:-}" ]; then
-        printf ',{"id":"FS_KEMs","ip":"%s/%s","port":"%s","severity":"OK","finding":"x25519mlkem768"}' "$ip" "$ip" "$port"
+        printf ',{"id":"FS_KEMs","ip":"%s/%s","port":"%s","severity":"OK","finding":"x25519mlkem768","service":"%s"}' "$ip" "$ip" "$port" "$SERVICE"
     fi
 done < "$TARGETS_FILE"
 printf ']'

--- a/scanner-job.yaml.template
+++ b/scanner-job.yaml.template
@@ -16,7 +16,7 @@ spec:
         args:
           - |
             # Run the scanner in the background and capture its exit code
-            /usr/local/bin/tls-scanner --all-pods -j ${SCANNER_PARALLEL:-4} --artifact-dir /artifacts --json-file /artifacts/results.json --csv-file /artifacts/results.csv --timing-file timing.txt --log-file /artifacts/scan.log ${NAMESPACE_FILTER_ARG} ${LIMIT_IPS_ARG} &
+            /usr/local/bin/tls-scanner --all-pods -j ${SCANNER_PARALLEL:-4} --artifact-dir /artifacts --json-file /artifacts/results.json --csv-file /artifacts/results.csv --timing-file timing.txt --log-file /artifacts/scan.log ${NAMESPACE_FILTER_ARG} ${LIMIT_IPS_ARG} ${STARTTLS_PORTS_ARG} &
             
             SCANNER_PID=$!
             


### PR DESCRIPTION
This PR adds `STARTTLS` protocol support to tls-scanner, so that databases like PostgreSQL are not detected as `NO_TLS`.

By default, `STARTTLS` is auto-detected when process-name discovery is available (e.g. /proc identifies postgres or mysqld). If process identity is unavailable, `tls-scanner` does not guess by port and performs a normal TLS scan unless `--starttls-ports` is explicitly set.

For manual control, the `--starttls-ports` flag allows explicit protocol-to-port mapping, supporting all STARTTLS protocols that testssl.sh supports: `ftp`, `smtp`, `lmtp`, `pop3`, `imap`, `xmpp`,`xmpp-server`, `telnet`, `ldap`, `nntp`, `sieve`, `postgres`, `mysql`.

Example:
  `--starttls-ports postgres=5432:6432,mysql=3306`

Explicit mappings take priority over auto-detection.

For in-cluster deployments via `deploy.sh`, set the `STARTTLS_PORTS` environment variable (same format).

Scan results with RHACS: https://docs.google.com/spreadsheets/d/1ayHWjOJ2LQKNiZli3cZ774Y19CHTVYkyP6v1qEpo75I/edit?usp=sharing
Note the several `postgres` pods (scanner-db, scanner-v4-db, central-db) that are now detected correctly.