### PR TITLE
Fix --tls-profile-type not enforcing compliance failures

### DIFF
--- a/cmd/tls-scanner/main.go
+++ b/cmd/tls-scanner/main.go
@@ -196,7 +196,7 @@ func run(args []string) (exitCode int) {
 			return 0
 		}
 
-		scanResults := scanner.Scan(jobs, *concurrentScans, nil, nil, policy, timeouts)
+		scanResults := scanner.Scan(jobs, *concurrentScans, nil, tlsProfileOverride, policy, timeouts)
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
@@ -219,7 +219,7 @@ func run(args []string) (exitCode int) {
 			return 1
 		}
 
-		scanResults := scanner.Scan(jobs, *concurrentScans, nil, nil, policy, timeouts)
+		scanResults := scanner.Scan(jobs, *concurrentScans, nil, tlsProfileOverride, policy, timeouts)
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
@@ -311,7 +311,7 @@ func run(args []string) (exitCode int) {
 		return 0
 	}
 
-	scanResults := scanner.Scan(jobs, *concurrentScans, client, nil, policy, timeouts)
+	scanResults := scanner.Scan(jobs, *concurrentScans, client, tlsProfileOverride, policy, timeouts)
 	finalScanResults = &scanResults
 
 	if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {

--- a/internal/k8s/tls.go
+++ b/internal/k8s/tls.go
@@ -165,6 +165,10 @@ func (c *Client) getKubeletTLS(fallback *APIServerTLSProfile) (*KubeletTLSProfil
 // explicit override inherit the APIServer profile, matching standalone OpenShift
 // behavior. Used when the cluster APIServer CR does not reflect the effective
 // profile, such as HyperShift hosted control planes.
+//
+// TLSAdherence is set to StrictAllComponents because explicitly supplying a
+// profile on the CLI is an unambiguous opt-in to enforcement — compliance
+// failures must be reported regardless of the cluster's tlsAdherence setting.
 func NewTLSSecurityProfileFromType(profileType string) (*TLSSecurityProfile, error) {
 	var normalized configv1.TLSProfileType
 	switch strings.ToLower(strings.TrimSpace(profileType)) {
@@ -186,7 +190,8 @@ func NewTLSSecurityProfileFromType(profileType string) (*TLSSecurityProfile, err
 	}
 
 	return &TLSSecurityProfile{
-		APIServer: apiServer,
+		TLSAdherence: configv1.TLSAdherencePolicyStrictAllComponents,
+		APIServer:    apiServer,
 		IngressController: &IngressTLSProfile{
 			Type:          apiServer.Type,
 			Ciphers:       apiServer.Ciphers,

--- a/internal/k8s/tls_test.go
+++ b/internal/k8s/tls_test.go
@@ -22,6 +22,24 @@ func TestNewTLSSecurityProfileFromTypeModern(t *testing.T) {
 	}
 }
 
+// TestNewTLSSecurityProfileFromTypeEnforcesCompliance verifies that a profile
+// built from a CLI-supplied type always sets TLSAdherence to
+// StrictAllComponents. Without this, HasComplianceFailures short-circuits to
+// false and compliance violations are silently swallowed.
+func TestNewTLSSecurityProfileFromTypeEnforcesCompliance(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"Old", "Intermediate", "Modern"} {
+		got, err := NewTLSSecurityProfileFromType(name)
+		if err != nil {
+			t.Fatalf("NewTLSSecurityProfileFromType(%q) error = %v", name, err)
+		}
+		if got.TLSAdherence != configv1.TLSAdherencePolicyStrictAllComponents {
+			t.Errorf("%s: TLSAdherence = %q, want StrictAllComponents", name, got.TLSAdherence)
+		}
+	}
+}
+
 func TestNewTLSSecurityProfileFromTypeInvalid(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scanner/compliance_test.go
+++ b/internal/scanner/compliance_test.go
@@ -8,6 +8,50 @@ import (
 	"github.com/openshift/tls-scanner/internal/k8s"
 )
 
+// TestHardcodedProfileEnforcesCompliance is the end-to-end test for the
+// --tls-profile-type flag. It proves that a profile built by
+// NewTLSSecurityProfileFromType causes HasComplianceFailures to return true
+// when a port is non-compliant — and would return false without the
+// TLSAdherence fix (the regression we guard against).
+func TestHardcodedProfileEnforcesCompliance(t *testing.T) {
+	t.Parallel()
+
+	profile, err := k8s.NewTLSSecurityProfileFromType("Intermediate")
+	if err != nil {
+		t.Fatalf("NewTLSSecurityProfileFromType: %v", err)
+	}
+
+	// A port that fails the version check: offers only TLS 1.0, but Intermediate
+	// requires >= TLS 1.2.
+	nonCompliantResult := ScanResults{
+		TLSSecurityConfig: profile,
+		IPResults: []IPResult{{
+			PortResults: []PortResult{{
+				APIServerTLSConfigCompliance: &TLSConfigComplianceResult{
+					Version: false, // TLS version too low
+					Ciphers: true,
+				},
+			}},
+		}},
+	}
+
+	if !HasComplianceFailures(nonCompliantResult) {
+		t.Error("HasComplianceFailures = false; want true — hardcoded profile must enforce compliance")
+	}
+
+	// Regression guard: same results but TLSAdherence left unset (the old broken
+	// behavior). HasComplianceFailures must return false in that case, confirming
+	// the fix is what drives enforcement.
+	brokenProfile := *profile
+	brokenProfile.TLSAdherence = configv1.TLSAdherencePolicyNoOpinion
+	withoutFix := nonCompliantResult
+	withoutFix.TLSSecurityConfig = &brokenProfile
+
+	if HasComplianceFailures(withoutFix) {
+		t.Error("regression check: HasComplianceFailures = true with NoOpinion adherence; that should not happen")
+	}
+}
+
 func intermediateProfile() *k8s.TLSSecurityProfile {
 	return &k8s.TLSSecurityProfile{
 		APIServer: &k8s.APIServerTLSProfile{


### PR DESCRIPTION
NewTLSSecurityProfileFromType returned a TLSSecurityProfile with TLSAdherence unset (""). HasComplianceFailures gates on EnforceTLSConfigComplianceFailures, which returns false for NoOpinion and LegacyAdheringComponentsOnly, so every compliance violation was silently swallowed when --tls-profile-type was supplied.

Set TLSAdherence = StrictAllComponents in NewTLSSecurityProfileFromType. An explicit CLI profile is an unambiguous opt-in to enforcement, so non-compliant ports must cause a non-zero exit code regardless of what the cluster's tlsAdherence field says.