### PR TITLE
Expand STARTTLS auto-detection to more process names

### DIFF
--- a/internal/scanner/starttls.go
+++ b/internal/scanner/starttls.go
@@ -26,8 +26,11 @@ var knownStarttlsProtocols = map[string]bool{
 }
 
 var commToStarttls = map[string]string{
-	"postgres": "postgres",
-	"mysqld":   "mysql",
+	"postgres":   "postgres",
+	"postmaster": "postgres",
+	"pgbouncer":  "postgres",
+	"mysqld":     "mysql",
+	"mariadbd":   "mysql",
 }
 
 func StarttlsProtoForProcess(comm string) string {

--- a/internal/scanner/starttls_test.go
+++ b/internal/scanner/starttls_test.go
@@ -11,7 +11,10 @@ func TestStarttlsProtoForProcess(t *testing.T) {
 		want string
 	}{
 		{"postgres", "postgres"},
+		{"postmaster", "postgres"},
+		{"pgbouncer", "postgres"},
 		{"mysqld", "mysql"},
+		{"mariadbd", "mysql"},
 		{"nginx", ""},
 		{"", ""},
 	} {


### PR DESCRIPTION
Add `postmaster` (legacy PostgreSQL), `pgbouncer` (PostgreSQL pooler), and `mariadbd` to the process-name auto-detection map.