### PR TITLE
DPTP-5102: Fix hostNetwork pod port ownership leak by scoping process cache per pod

### DIFF
--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -66,6 +66,7 @@ func NewClient() (*Client, error) {
 		processNameMap:    make(map[string]map[int]string),
 		listenInfoMap:     make(map[string]map[int]ListenInfo),
 		procListenAddrMap: make(map[string]map[int]string),
+		podOwnedPorts:     make(map[string]map[int]bool),
 		namespace:         namespace,
 		configClient:      configClient,
 		operatorClient:    operatorClient,

--- a/internal/k8s/process.go
+++ b/internal/k8s/process.go
@@ -4,6 +4,11 @@ func (c *Client) cacheProcListenInfo(pod PodInfo, entries map[int]ProcListenEntr
 	c.processCacheMutex.Lock()
 	defer c.processCacheMutex.Unlock()
 
+	podKey := podOwnershipKey(pod)
+	if _, ok := c.podOwnedPorts[podKey]; !ok {
+		c.podOwnedPorts[podKey] = make(map[int]bool)
+	}
+
 	for _, ip := range pod.IPs {
 		if _, ok := c.procListenAddrMap[ip]; !ok {
 			c.procListenAddrMap[ip] = make(map[int]string)
@@ -28,31 +33,48 @@ func (c *Client) cacheProcListenInfo(pod PodInfo, entries map[int]ProcListenEntr
 				ListenAddress: entry.Addr,
 				ProcessName:   comm,
 			}
+			// Ownership is scoped to THIS pod only — never merged with other
+			// pods, even ones sharing the same IP (see podOwnedPorts doc).
+			c.podOwnedPorts[podKey][port] = true
 		}
 	}
 }
 
-// GetCachedProcessMap returns per-IP port→process maps populated by DiscoverPortsFromProc.
-func (c *Client) GetCachedProcessMap(ips []string) map[string]map[int]string {
+// podOwnershipKey uniquely identifies a pod for ownership-scoping purposes.
+// Deliberately independent of IP, since hostNetwork pods share the node's IP.
+func podOwnershipKey(pod PodInfo) string {
+	return pod.Namespace + "/" + pod.Name
+}
+
+// GetOwnedPorts returns the set of ports whose listening process was resolved
+// specifically within pod's own PID namespace (i.e. genuinely running in one
+// of the pod's own containers), as observed by a prior DiscoverPortsFromProc
+// call for this exact pod.
+//
+// This is intentionally NOT an IP-based lookup: for hostNetwork pods, many
+// unrelated pods on the same node report the same IP, so keying by IP alone
+// would return ports resolved by other pods entirely (see issue #85).
+//
+// A nil return means /proc discovery never ran (or found nothing at all) for
+// this pod, i.e. cacheProcListenInfo was never invoked. A non-nil, possibly
+// empty, map means discovery ran successfully but resolved zero ports to a
+// process in this pod's own PID namespace — a valid outcome (e.g. every
+// listening socket's inode belongs to another container's namespace), and
+// callers must still treat it as ground truth for filtering rather than
+// falling back as if ownership data were unavailable.
+func (c *Client) GetOwnedPorts(pod PodInfo) map[int]bool {
 	c.processCacheMutex.Lock()
 	defer c.processCacheMutex.Unlock()
 
-	result := make(map[string]map[int]string)
-	for _, ip := range ips {
-		portMap, ok := c.processNameMap[ip]
-		if !ok || len(portMap) == 0 {
-			continue
-		}
-		copied := make(map[int]string, len(portMap))
-		for port, name := range portMap {
-			copied[port] = name
-		}
-		result[ip] = copied
-	}
-	if len(result) == 0 {
+	owned, ok := c.podOwnedPorts[podOwnershipKey(pod)]
+	if !ok {
 		return nil
 	}
-	return result
+	copied := make(map[int]bool, len(owned))
+	for port := range owned {
+		copied[port] = true
+	}
+	return copied
 }
 
 func (c *Client) IsLocalhostOnly(ip string, port int) (bool, string) {

--- a/internal/k8s/process_test.go
+++ b/internal/k8s/process_test.go
@@ -11,6 +11,7 @@ func newTestClient() *Client {
 		processNameMap:    make(map[string]map[int]string),
 		listenInfoMap:     make(map[string]map[int]ListenInfo),
 		procListenAddrMap: make(map[string]map[int]string),
+		podOwnedPorts:     make(map[string]map[int]bool),
 	}
 }
 
@@ -74,22 +75,109 @@ func TestCacheProcListenInfo(t *testing.T) {
 	if _, ok := c.processNameMap["10.0.0.1"][8080]; ok {
 		t.Error("expected no process name for port without inode mapping")
 	}
+	if !c.podOwnedPorts[podOwnershipKey(pod)][443] {
+		t.Error("expected port 443 to be recorded as owned by pod")
+	}
+	if c.podOwnedPorts[podOwnershipKey(pod)][8080] {
+		t.Error("expected port 8080 (no inode mapping) to not be recorded as owned")
+	}
 }
 
-func TestGetCachedProcessMap(t *testing.T) {
+func TestGetOwnedPorts(t *testing.T) {
 	c := newTestClient()
-	c.processNameMap["10.0.0.1"] = map[int]string{443: "nginx", 8443: "sidecar"}
-
-	got := c.GetCachedProcessMap([]string{"10.0.0.1", "10.0.0.2"})
-	if got["10.0.0.1"][443] != "nginx" || got["10.0.0.1"][8443] != "sidecar" {
-		t.Errorf("GetCachedProcessMap() = %v", got)
+	pod := PodInfo{Namespace: "ns", Name: "pod-a", IPs: []string{"10.0.0.1"}}
+	entries := map[int]ProcListenEntry{
+		443:  {Addr: "0.0.0.0", Inode: 1},
+		8443: {Addr: "0.0.0.0", Inode: 2},
 	}
-	if _, ok := got["10.0.0.2"]; ok {
-		t.Error("expected no entry for IP without process data")
+	inodeComm := map[uint64]string{1: "nginx", 2: "sidecar"}
+	c.cacheProcListenInfo(pod, entries, inodeComm)
+
+	got := c.GetOwnedPorts(pod)
+	if !got[443] || !got[8443] {
+		t.Errorf("GetOwnedPorts() = %v, want ports 443 and 8443 owned", got)
 	}
 
-	if c.GetCachedProcessMap(nil) != nil {
-		t.Error("expected nil for empty ips with no cache")
+	other := PodInfo{Namespace: "ns", Name: "pod-b", IPs: []string{"10.0.0.2"}}
+	if c.GetOwnedPorts(other) != nil {
+		t.Error("expected nil for pod with no cached ownership data")
+	}
+}
+
+// TestGetOwnedPorts_EmptyOwnershipIsNotNil reproduces a bug where a pod with
+// non-empty /proc/net/tcp results but zero resolvable inode-to-process
+// matches (e.g. every listening socket belongs to another container's PID
+// namespace) was indistinguishable from a pod for which /proc discovery
+// never ran at all. Both cases populated podOwnedPorts with an empty map,
+// but GetOwnedPorts collapsed "discovered, nothing owned" into nil, which
+// callers use as a signal to skip filtering entirely — silently letting
+// unrelated host listeners through on hostNetwork pods.
+func TestGetOwnedPorts_EmptyOwnershipIsNotNil(t *testing.T) {
+	c := newTestClient()
+	pod := PodInfo{Namespace: "ns", Name: "pod-c", IPs: []string{"10.0.0.3"}}
+
+	// Non-empty /proc results (entries), but no inode resolves to a process
+	// visible in this pod's own PID namespace.
+	entries := map[int]ProcListenEntry{
+		9100: {Addr: "0.0.0.0", Inode: 42},
+	}
+	inodeComm := map[uint64]string{} // no matches
+	c.cacheProcListenInfo(pod, entries, inodeComm)
+
+	got := c.GetOwnedPorts(pod)
+	if got == nil {
+		t.Fatal("GetOwnedPorts() = nil, want non-nil empty map for a pod with a successfully " +
+			"populated but empty ownership set")
+	}
+	if len(got) != 0 {
+		t.Errorf("GetOwnedPorts() = %v, want empty map", got)
+	}
+
+	// A pod for which discovery never ran must still report nil, so callers
+	// can distinguish "no data" from "data says nothing is owned".
+	neverDiscovered := PodInfo{Namespace: "ns", Name: "pod-d", IPs: []string{"10.0.0.4"}}
+	if c.GetOwnedPorts(neverDiscovered) != nil {
+		t.Error("expected nil for pod with no cached ownership data")
+	}
+}
+
+// TestGetOwnedPorts_NoLeakAcrossUkrelatedHostNetworkPods reproduces a port
+// misattribution bug when the pod is a hostNetwork pod.
+func TestGetOwnedPorts_NoLeakAcrossUnrelatedHostNetworkPods(t *testing.T) {
+	c := newTestClient()
+	nodeIP := "10.0.1.5"
+
+	ovnkubePod := PodInfo{Namespace: "openshift-ovn-kubernetes", Name: "ovnkube-node-abc12", IPs: []string{nodeIP}}
+	ovnkubeEntries := map[int]ProcListenEntry{
+		9103: {Addr: "0.0.0.0", Inode: 1},
+		9105: {Addr: "0.0.0.0", Inode: 2},
+	}
+	ovnkubeInodeComm := map[uint64]string{1: "ovnkube-controller", 2: "ovnkube-controller"}
+	c.cacheProcListenInfo(ovnkubePod, ovnkubeEntries, ovnkubeInodeComm)
+
+	filestorePod := PodInfo{
+		Namespace: "openshift-cluster-csi-drivers",
+		Name:      "gcp-filestore-csi-driver-controller-548d7c67d6-db7tx",
+		IPs:       []string{nodeIP},
+	}
+	filestoreEntries := map[int]ProcListenEntry{
+		9212: {Addr: "0.0.0.0", Inode: 3},
+	}
+	filestoreInodeComm := map[uint64]string{3: "kube-rbac-proxy"}
+	c.cacheProcListenInfo(filestorePod, filestoreEntries, filestoreInodeComm)
+
+	owned := c.GetOwnedPorts(filestorePod)
+
+	if owned[9103] {
+		t.Error("GetOwnedPorts() for the filestore pod incorrectly includes port 9103, " +
+			"owned by ovnkube-node, not the filestore controller (see issue #85)")
+	}
+	if owned[9105] {
+		t.Error("GetOwnedPorts() for the filestore pod incorrectly includes port 9105, " +
+			"owned by ovnkube-node, not the filestore controller (see issue #85)")
+	}
+	if !owned[9212] {
+		t.Error("GetOwnedPorts() for the filestore pod should still include its own port 9212")
 	}
 }
 

--- a/internal/k8s/types.go
+++ b/internal/k8s/types.go
@@ -77,6 +77,16 @@ type Client struct {
 	// procListenAddrMap holds the decoded listen address for every port seen in
 	// /proc/net/tcp(6). It covers all containers in a pod (shared network namespace).
 	procListenAddrMap map[string]map[int]string
+	// podOwnedPorts holds, per pod (keyed by "namespace/name"), the set of
+	// ports whose listening socket inode was resolved to a process visible in
+	// THAT pod's own PID namespace. Unlike processNameMap/listenInfoMap (which
+	// are intentionally keyed by IP and shared across every pod that reports
+	// it, since a given ip:port has exactly one real listener), ownership for
+	// filtering purposes must never be merged across pods: hostNetwork pods on
+	// the same node all share the node's IP, so an IP-keyed lookup would leak
+	// ports legitimately owned by one hostNetwork pod (e.g. ovnkube-node) into
+	// the scan target list of a completely unrelated one (see issue #85).
+	podOwnedPorts     map[string]map[int]bool
 	processCacheMutex sync.Mutex
 	namespace         string
 	configClient      *configclientset.Clientset

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -89,17 +89,26 @@ func DiscoverTargets(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client
 					}
 				}
 
-				var processMap map[string]map[int]string
+				var ownedPorts map[int]bool
 				if client != nil && procAvailable {
-					processMap = client.GetCachedProcessMap(pod.IPs)
+					// Ownership must be resolved per-pod, not per-IP: hostNetwork
+					// pods share the node's IP, so an IP-keyed lookup would leak
+					// ports legitimately owned by other hostNetwork pods on the
+					// same node into this pod's scan target list (see issue #85).
+					ownedPorts = client.GetOwnedPorts(pod)
 				}
 
-				if pod.Pod.Spec.HostNetwork && processMap != nil && len(procPorts) > 0 {
+				// ownedPorts == nil means /proc discovery never ran for this pod, so
+				// there is nothing to filter by. An empty-but-non-nil ownedPorts is a
+				// valid discovery result (no port resolved to this pod's own PID
+				// namespace) and must still be filtered down to secondary-container
+				// spec ports, if any — it is not evidence that discovery failed.
+				if pod.Pod.Spec.HostNetwork && ownedPorts != nil && len(procPorts) > 0 {
 					var secondarySpecPorts []int
 					if len(pod.Containers) > 1 {
 						secondarySpecPorts = k8s.DiscoverPortsFromSecondaryContainers(pod.Pod, pod.Containers[0])
 					}
-					procPorts = filterByProcessPorts(processMap, procPorts, secondarySpecPorts)
+					procPorts = filterByProcessPorts(ownedPorts, procPorts, secondarySpecPorts)
 				}
 
 				// When /proc data is available use it as the ground truth — only
@@ -596,13 +605,18 @@ func LimitPodsToIPCount(pods []k8s.PodInfo, maxIPs int) []k8s.PodInfo {
 	return limitedPods
 }
 
-// filterByProcessPorts keeps procPorts owned by this pod (via /proc inode resolution or pod spec).
-func filterByProcessPorts(processMap map[string]map[int]string, procPorts []int, specPorts []int) []int {
-	owned := make(map[int]bool)
-	for _, portMap := range processMap {
-		for port := range portMap {
-			owned[port] = true
-		}
+// filterByProcessPorts keeps procPorts owned by this pod: either resolved via
+// /proc inode resolution scoped to this pod's own PID namespace (ownedPorts),
+// or declared in a secondary container's pod spec (specPorts).
+//
+// ownedPorts must come from a per-pod-scoped source (e.g. Client.GetOwnedPorts)
+// rather than a cache shared across pods on the same IP, otherwise ports
+// legitimately owned by a different hostNetwork pod on the same node can leak
+// through as false positives (see issue #85).
+func filterByProcessPorts(ownedPorts map[int]bool, procPorts []int, specPorts []int) []int {
+	owned := make(map[int]bool, len(ownedPorts)+len(specPorts))
+	for port := range ownedPorts {
+		owned[port] = true
 	}
 	for _, p := range specPorts {
 		owned[p] = true

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -746,52 +746,70 @@ func TestFilterByProcessPorts(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		processMap map[string]map[int]string
+		ownedPorts map[int]bool
 		procPorts  []int
 		specPorts  []int
 		want       []int
 	}{
 		{
-			name: "keeps process-mapped ports",
-			processMap: map[string]map[int]string{
-				"10.0.0.1": {9091: "main", 9043: "sidecar"},
-			},
-			procPorts: []int{9091, 9043, 6443, 10257},
-			specPorts: []int{9091, 9043},
-			want:      []int{9091, 9043},
+			name:       "keeps process-mapped ports",
+			ownedPorts: map[int]bool{9091: true, 9043: true},
+			procPorts:  []int{9091, 9043, 6443, 10257},
+			specPorts:  []int{9091, 9043},
+			want:       []int{9091, 9043},
 		},
 		{
-			name: "spec-declared port preserved when process map misses it",
-			processMap: map[string]map[int]string{
-				"10.0.0.1": {9091: "main", 9043: "sidecar"},
-			},
-			procPorts: []int{9091, 9043, 8443, 6443, 10257},
-			specPorts: []int{9091, 9043, 8443},
-			want:      []int{9091, 9043, 8443},
+			name:       "spec-declared port preserved when process map misses it",
+			ownedPorts: map[int]bool{9091: true, 9043: true},
+			procPorts:  []int{9091, 9043, 8443, 6443, 10257},
+			specPorts:  []int{9091, 9043, 8443},
+			want:       []int{9091, 9043, 8443},
 		},
 		{
-			name: "unowned port not in spec still dropped",
-			processMap: map[string]map[int]string{
-				"10.0.0.1": {9091: "main"},
-			},
-			procPorts: []int{9091, 6443, 10257},
-			specPorts: []int{9091},
-			want:      []int{9091},
+			name:       "unowned port not in spec still dropped",
+			ownedPorts: map[int]bool{9091: true},
+			procPorts:  []int{9091, 6443, 10257},
+			specPorts:  []int{9091},
+			want:       []int{9091},
 		},
 		{
-			name: "nil specPorts — only process-owned ports kept",
-			processMap: map[string]map[int]string{
-				"10.0.0.1": {9091: "main"},
-			},
-			procPorts: []int{9091, 6443, 10257},
-			specPorts: nil,
-			want:      []int{9091},
+			name:       "nil specPorts — only process-owned ports kept",
+			ownedPorts: map[int]bool{9091: true},
+			procPorts:  []int{9091, 6443, 10257},
+			specPorts:  nil,
+			want:       []int{9091},
+		},
+		{
+			name:       "ports owned by another pod are not credited to this one",
+			ownedPorts: map[int]bool{9212: true},
+			procPorts:  []int{9212, 9103, 9105, 9108},
+			specPorts:  nil,
+			want:       []int{9212},
+		},
+		{
+			// A successfully discovered but empty ownership set (e.g. every
+			// listening socket's inode belongs to another container's PID
+			// namespace) must still be filtered down to only the ports declared
+			// by secondary containers — it is not evidence that discovery was
+			// unavailable, and must not fall back to keeping every proc port.
+			name:       "empty but non-nil ownedPorts still filters down to secondary spec ports",
+			ownedPorts: map[int]bool{},
+			procPorts:  []int{9100, 9101, 9102},
+			specPorts:  []int{9101},
+			want:       []int{9101},
+		},
+		{
+			name:       "empty but non-nil ownedPorts with no spec ports drops everything",
+			ownedPorts: map[int]bool{},
+			procPorts:  []int{9100, 9101, 9102},
+			specPorts:  nil,
+			want:       nil,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := filterByProcessPorts(tt.processMap, tt.procPorts, tt.specPorts)
+			got := filterByProcessPorts(tt.ownedPorts, tt.procPorts, tt.specPorts)
 			slices.Sort(got)
 			slices.Sort(tt.want)
 			if !slices.Equal(got, tt.want) {


### PR DESCRIPTION
Previously process ownership was keyed by IP, so hostNetwork pods sharing a node IP could inherit ports resolved from unrelated pods (e.g. ovnkube-node). Add a podOwnedPorts cache keyed by namespace/name and Client.GetOwnedPorts to return only ports whose listening process was resolved in that pod's own PID namespace. Update the scanner's filterByProcessPorts to use the per-pod owned set instead of an IP-based process map.