### PR TITLE
DPTP-5114: Split scanner CPU/memory request and limit configuration

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -222,7 +222,28 @@ EOF
     SCANNER_MEM_LIMIT="${SCANNER_MEM_LIMIT:-${SCANNER_MEM:-4Gi}}"
     SCANNER_PARALLEL="${SCANNER_PARALLEL:-4}"
     ARTIFACT_WAIT="${ARTIFACT_WAIT:-30}"
-    sed -e "s|\\\${SCANNER_IMAGE}|${SCANNER_IMAGE}|g" -e "s|\\\${NAMESPACE}|${NAMESPACE}|g" -e "s|\\\${JOB_NAME}|${JOB_NAME}|g" -e "s|\\\${NAMESPACE_FILTER_ARG}|${NAMESPACE_FILTER_ARG}|g" -e "s|\\\${LIMIT_IPS_ARG}|${LIMIT_IPS_ARG}|g" -e "s|\\\${STARTTLS_PORTS_ARG}|${STARTTLS_PORTS_ARG}|g" -e "s|\\\${SCANNER_CPU_REQUEST:-500m}|${SCANNER_CPU_REQUEST}|g" -e "s|\\\${SCANNER_CPU_LIMIT:-4}|${SCANNER_CPU_LIMIT}|g" -e "s|\\\${SCANNER_MEM_REQUEST:-4Gi}|${SCANNER_MEM_REQUEST}|g" -e "s|\\\${SCANNER_MEM_LIMIT:-4Gi}|${SCANNER_MEM_LIMIT}|g" -e "s|\\\${SCANNER_PARALLEL:-4}|${SCANNER_PARALLEL}|g" -e "s|\\\${ARTIFACT_WAIT:-300}|${ARTIFACT_WAIT}|g" "$JOB_TEMPLATE" | oc apply -f -
+
+    # Render to a temp file first (rather than piping straight into `oc apply`)
+    # so we can server-side dry-run it and catch template/resource mistakes
+    # (e.g. inconsistent SCANNER_*_REQUEST/LIMIT values) before actually
+    # applying anything.
+    RENDERED_JOB=$(mktemp)
+    check_error "Creating temp file for rendered Job manifest"
+    # Use an EXIT trap (rather than RETURN) so the temp file is still cleaned
+    # up if we exit early below (e.g. on a failed dry-run), not just on a
+    # normal function return.
+    trap 'rm -f "$RENDERED_JOB"' EXIT
+
+    sed -e "s|\\\${SCANNER_IMAGE}|${SCANNER_IMAGE}|g" -e "s|\\\${NAMESPACE}|${NAMESPACE}|g" -e "s|\\\${JOB_NAME}|${JOB_NAME}|g" -e "s|\\\${NAMESPACE_FILTER_ARG}|${NAMESPACE_FILTER_ARG}|g" -e "s|\\\${LIMIT_IPS_ARG}|${LIMIT_IPS_ARG}|g" -e "s|\\\${STARTTLS_PORTS_ARG}|${STARTTLS_PORTS_ARG}|g" -e "s|\\\${SCANNER_CPU_REQUEST:-500m}|${SCANNER_CPU_REQUEST}|g" -e "s|\\\${SCANNER_CPU_LIMIT:-4}|${SCANNER_CPU_LIMIT}|g" -e "s|\\\${SCANNER_MEM_REQUEST:-4Gi}|${SCANNER_MEM_REQUEST}|g" -e "s|\\\${SCANNER_MEM_LIMIT:-4Gi}|${SCANNER_MEM_LIMIT}|g" -e "s|\\\${SCANNER_PARALLEL:-4}|${SCANNER_PARALLEL}|g" -e "s|\\\${ARTIFACT_WAIT:-300}|${ARTIFACT_WAIT}|g" "$JOB_TEMPLATE" > "$RENDERED_JOB"
+    check_error "Rendering Job manifest"
+
+    echo "--> Validating rendered Job manifest (server-side dry-run)..."
+    if ! oc apply --dry-run=server -f "$RENDERED_JOB"; then
+        echo "Error: Invalid Job manifest (check SCANNER_*_REQUEST/LIMIT values)"
+        exit 1
+    fi
+
+    oc apply -f "$RENDERED_JOB"
     check_error "Applying Job manifest"
 
     echo "--> Scanner Job '${JOB_NAME}' deployed."

--- a/deploy.sh
+++ b/deploy.sh
@@ -17,8 +17,12 @@
 #   NAMESPACE        - Target namespace (default: current oc project)
 #   NAMESPACE_FILTER - Comma-separated namespace list to scan
 #   LIMIT_IPS        - Limit number of IPs to scan (default: 0 = no limit)
-#   SCANNER_CPU      - CPU request/limit for scanner pod (default: 4)
-#   SCANNER_MEM      - Memory request/limit for scanner pod (default: 4Gi)
+#   SCANNER_CPU_REQUEST - CPU request for scanner pod (default: 500m; falls back to SCANNER_CPU if set)
+#   SCANNER_CPU_LIMIT   - CPU limit for scanner pod (default: 4; falls back to SCANNER_CPU if set)
+#   SCANNER_CPU      - (Deprecated) Sets both CPU request and limit if the vars above are unset
+#   SCANNER_MEM_REQUEST - Memory request for scanner pod (default: 4Gi; falls back to SCANNER_MEM if set)
+#   SCANNER_MEM_LIMIT   - Memory limit for scanner pod (default: 4Gi; falls back to SCANNER_MEM if set)
+#   SCANNER_MEM      - (Deprecated) Sets both memory request and limit if the vars above are unset
 #   SCANNER_PARALLEL - Parallel scan count (default: 4)
 #   ARTIFACT_WAIT    - Seconds to keep pod alive after scan for artifact collection (default: 30, CI uses 300)
 #   TLS_TEST_TIMEOUT - Timeout for cluster stabilization during TLS tests (default: 600)
@@ -208,11 +212,17 @@ EOF
         STARTTLS_PORTS_ARG="--starttls-ports $(echo "${STARTTLS_PORTS}" | tr -d ' ')"
     fi
 
-    SCANNER_CPU="${SCANNER_CPU:-4}"
-    SCANNER_MEM="${SCANNER_MEM:-4Gi}"
+    # SCANNER_CPU/SCANNER_MEM are deprecated but still honored as fallback
+    # defaults for both request and limit when the split vars aren't
+    # explicitly set, so that a lower CPU request (e.g. 500m) can get the
+    # Pod scheduled while still allowing it to burst up to the higher limit.
+    SCANNER_CPU_REQUEST="${SCANNER_CPU_REQUEST:-${SCANNER_CPU:-500m}}"
+    SCANNER_CPU_LIMIT="${SCANNER_CPU_LIMIT:-${SCANNER_CPU:-4}}"
+    SCANNER_MEM_REQUEST="${SCANNER_MEM_REQUEST:-${SCANNER_MEM:-4Gi}}"
+    SCANNER_MEM_LIMIT="${SCANNER_MEM_LIMIT:-${SCANNER_MEM:-4Gi}}"
     SCANNER_PARALLEL="${SCANNER_PARALLEL:-4}"
     ARTIFACT_WAIT="${ARTIFACT_WAIT:-30}"
-    sed -e "s|\\\${SCANNER_IMAGE}|${SCANNER_IMAGE}|g" -e "s|\\\${NAMESPACE}|${NAMESPACE}|g" -e "s|\\\${JOB_NAME}|${JOB_NAME}|g" -e "s|\\\${NAMESPACE_FILTER_ARG}|${NAMESPACE_FILTER_ARG}|g" -e "s|\\\${LIMIT_IPS_ARG}|${LIMIT_IPS_ARG}|g" -e "s|\\\${STARTTLS_PORTS_ARG}|${STARTTLS_PORTS_ARG}|g" -e "s|\\\${SCANNER_CPU:-4}|${SCANNER_CPU}|g" -e "s|\\\${SCANNER_MEM:-4Gi}|${SCANNER_MEM}|g" -e "s|\\\${SCANNER_PARALLEL:-4}|${SCANNER_PARALLEL}|g" -e "s|\\\${ARTIFACT_WAIT:-300}|${ARTIFACT_WAIT}|g" "$JOB_TEMPLATE" | oc apply -f -
+    sed -e "s|\\\${SCANNER_IMAGE}|${SCANNER_IMAGE}|g" -e "s|\\\${NAMESPACE}|${NAMESPACE}|g" -e "s|\\\${JOB_NAME}|${JOB_NAME}|g" -e "s|\\\${NAMESPACE_FILTER_ARG}|${NAMESPACE_FILTER_ARG}|g" -e "s|\\\${LIMIT_IPS_ARG}|${LIMIT_IPS_ARG}|g" -e "s|\\\${STARTTLS_PORTS_ARG}|${STARTTLS_PORTS_ARG}|g" -e "s|\\\${SCANNER_CPU_REQUEST:-500m}|${SCANNER_CPU_REQUEST}|g" -e "s|\\\${SCANNER_CPU_LIMIT:-4}|${SCANNER_CPU_LIMIT}|g" -e "s|\\\${SCANNER_MEM_REQUEST:-4Gi}|${SCANNER_MEM_REQUEST}|g" -e "s|\\\${SCANNER_MEM_LIMIT:-4Gi}|${SCANNER_MEM_LIMIT}|g" -e "s|\\\${SCANNER_PARALLEL:-4}|${SCANNER_PARALLEL}|g" -e "s|\\\${ARTIFACT_WAIT:-300}|${ARTIFACT_WAIT}|g" "$JOB_TEMPLATE" | oc apply -f -
     check_error "Applying Job manifest"
 
     echo "--> Scanner Job '${JOB_NAME}' deployed."

--- a/scanner-job.yaml.template
+++ b/scanner-job.yaml.template
@@ -44,11 +44,11 @@ spec:
             exit 0
         resources:
           requests:
-            cpu: "${SCANNER_CPU:-4}"
-            memory: "${SCANNER_MEM:-4Gi}"
+            cpu: "${SCANNER_CPU_REQUEST:-500m}"
+            memory: "${SCANNER_MEM_REQUEST:-4Gi}"
           limits:
-            cpu: "${SCANNER_CPU:-4}"
-            memory: "${SCANNER_MEM:-4Gi}"
+            cpu: "${SCANNER_CPU_LIMIT:-4}"
+            memory: "${SCANNER_MEM_LIMIT:-4Gi}"
         securityContext:
           privileged: true
         volumeMounts:


### PR DESCRIPTION
Replaces SCANNER_CPU and SCANNER_MEM with SCANNER_CPU_{REQUEST,LIMIT} SCANNER_MEM_{REQUEST,LIMIT} while keeping the (now deprecated) SCANNER_CPU and SCANNER_MEM for for backwards compat with existing workflows.