### PR TITLE
feat: implement SNI capability

### DIFF
--- a/cmd/tls-scanner/main.go
+++ b/cmd/tls-scanner/main.go
@@ -76,6 +76,7 @@ func run(args []string) (exitCode int) {
 	connectTimeout := fs.Int("connect-timeout", scanner.DefaultScanTimeouts.ConnectTimeout, "Timeout in seconds for testssl.sh connect and openssl operations")
 	tlsProfileType := fs.String("tls-profile-type", "", "Expected cluster TLS profile type for compliance checks (Old, Intermediate, Modern). When set, skips reading APIServer/cluster from the API.")
 	starttlsPortsFlag := fs.String("starttls-ports", "", "STARTTLS protocol-to-port mapping (e.g., postgres=5432:6432,mysql=3306)")
+	sniHostname := fs.String("sni-hostname", "", "Override the TLS SNI servername sent to every target. The connection is still made to each target's own IP; this only affects the handshake's servername. Use for services that route by SNI (e.g. Envoy/Gateway API) and reject handshakes without the expected hostname. Typically paired with --component-filter/--namespace-filter/--targets so only pods actually serving this hostname are scanned.")
 
 	if err := fs.Parse(args); err != nil {
 		return 2
@@ -190,7 +191,7 @@ func run(args []string) (exitCode int) {
 				slog.Warn("skipping invalid target format", "target", t, "expected", "host:port")
 				continue
 			}
-			jobs = append(jobs, scanner.ScanJob{IP: hostValue, Port: portValue})
+			jobs = append(jobs, scanner.ScanJob{IP: hostValue, Port: portValue, SNIHostname: *sniHostname})
 		}
 
 		if len(jobs) == 0 {
@@ -224,6 +225,11 @@ func run(args []string) (exitCode int) {
 		if err != nil {
 			slog.Error("loading template", "error", err)
 			return 1
+		}
+		if *sniHostname != "" {
+			for i := range jobs {
+				jobs[i].SNIHostname = *sniHostname
+			}
 		}
 
 		scanResults := scanner.Scan(jobs, *concurrentScans, nil, tlsProfileOverride, policy, timeouts, starttlsPorts)
@@ -283,13 +289,13 @@ func run(args []string) (exitCode int) {
 	}
 
 	if len(pods) > 0 && *dryRun {
-		discovery := scanner.DiscoverTargets(pods, *concurrentScans, client)
+		discovery := scanner.DiscoverTargets(pods, *concurrentScans, client, *sniHostname)
 		output.PrintDryRunResults(discovery)
 		return 0
 	}
 
 	if len(pods) > 0 {
-		scanResults := scanner.PerformClusterScan(pods, *concurrentScans, client, policy, timeouts, tlsProfileOverride, starttlsPorts)
+		scanResults := scanner.PerformClusterScan(pods, *concurrentScans, client, policy, timeouts, tlsProfileOverride, starttlsPorts, *sniHostname)
 		finalScanResults = &scanResults
 
 		if err := output.WriteOutputFiles(scanResults, *artifactDir, *jsonFile, *csvFile, *junitFile, isPQCCheck); err != nil {
@@ -311,7 +317,7 @@ func run(args []string) (exitCode int) {
 		return 1
 	}
 
-	jobs := []scanner.ScanJob{{IP: normalizeHost(*host), Port: portNum}}
+	jobs := []scanner.ScanJob{{IP: normalizeHost(*host), Port: portNum, SNIHostname: *sniHostname}}
 
 	if *dryRun {
 		output.PrintDryRunTargets(jobs)

--- a/cmd/tls-scanner/main_test.go
+++ b/cmd/tls-scanner/main_test.go
@@ -156,6 +156,43 @@ func TestSingleHostPathIPv6(t *testing.T) {
 	}
 }
 
+func TestTargetsPathWithSNIHostname(t *testing.T) {
+	testutil.InstallMockTestSSL(t)
+	outDir := t.TempDir()
+
+	code := run([]string{
+		"--targets", "10.0.0.5:443",
+		"--sni-hostname", "gateway.example.com",
+		"--json-file", "results.json",
+		"--artifact-dir", outDir,
+		"-j", "1",
+	})
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d", code)
+	}
+
+	results := readJSONResults(t, outDir, "results.json")
+	if results.ScannedIPs != 1 {
+		t.Fatalf("expected 1 scanned IP, got %d", results.ScannedIPs)
+	}
+	if len(results.IPResults) == 0 {
+		t.Fatal("no IP results")
+	}
+
+	ir := results.IPResults[0]
+	// The result must be attributed to the connect IP, not the SNI hostname
+	// used only for the handshake.
+	if ir.IP != "10.0.0.5" {
+		t.Fatalf("expected result attributed to connect IP 10.0.0.5, got %s", ir.IP)
+	}
+	if len(ir.PortResults) == 0 {
+		t.Fatal("no port results")
+	}
+	if ir.PortResults[0].Status != scanner.StatusOK {
+		t.Errorf("expected status OK, got %s", ir.PortResults[0].Status)
+	}
+}
+
 func TestPQCCheckTargets(t *testing.T) {
 	testutil.InstallMockTestSSL(t)
 	outDir := t.TempDir()

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -44,7 +44,7 @@ func (d DiscoveryResults) SkippedPorts() []SkippedPort {
 	return out
 }
 
-func DiscoverTargets(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client) DiscoveryResults {
+func DiscoverTargets(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client, sniHostname string) DiscoveryResults {
 	defer timing.Timings.Track("discoverTargets", "")()
 
 	discoveryWorkers := max(2, concurrentScans/2)
@@ -205,7 +205,7 @@ func DiscoverTargets(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client
 
 						progress.PortQueued()
 						mu.Lock()
-						scanJobs = append(scanJobs, ScanJob{IP: ip, Port: port, Pod: pod, Component: component})
+						scanJobs = append(scanJobs, ScanJob{IP: ip, Port: port, Pod: pod, Component: component, SNIHostname: sniHostname})
 						mu.Unlock()
 					}
 				}
@@ -229,7 +229,7 @@ func DiscoverTargets(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client
 	return DiscoveryResults{ScanJobs: scanJobs, Skipped: skipped}
 }
 
-func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client, policy *ComponentPolicy, timeouts ScanTimeouts, tlsProfileOverride *k8s.TLSSecurityProfile, starttlsPorts StarttlsPorts) ScanResults {
+func PerformClusterScan(pods []k8s.PodInfo, concurrentScans int, client *k8s.Client, policy *ComponentPolicy, timeouts ScanTimeouts, tlsProfileOverride *k8s.TLSSecurityProfile, starttlsPorts StarttlsPorts, sniHostname string) ScanResults {
 	defer timing.Timings.Track("performClusterScan", "")()
 	startTime := time.Now()
 
@@ -262,7 +262,7 @@ MAX_PARALLEL (testssl): %d
 		}
 	}
 
-	discovery := DiscoverTargets(pods, concurrentScans, client)
+	discovery := DiscoverTargets(pods, concurrentScans, client, sniHostname)
 
 	batchResults := batchScan(discovery.ScanJobs, concurrentScans, client, tlsConfig, policy, timeouts, starttlsPorts)
 
@@ -363,7 +363,7 @@ func scanBatchGroup(jobs []ScanJob, concurrentScans int, starttls string, client
 	for _, job := range jobs {
 		key := targetKey(job.IP, strconv.Itoa(job.Port))
 		jobIndex[key] = job
-		targets = append(targets, key)
+		targets = append(targets, targetLine(job))
 	}
 
 	targetsFile, err := writeTargetsFile(targets)
@@ -698,6 +698,20 @@ func writeTargetsFile(targets []string) (string, error) {
 
 func targetKey(host, port string) string {
 	return net.JoinHostPort(normalizeTargetHost(host), port)
+}
+
+// targetLine builds the string written to testssl.sh's --file batch input for
+// job. Each line of that file is passed through as additional testssl.sh
+// arguments (see run_mass_testing/create_mass_testing_cmdline upstream), so a
+// line may carry flags in addition to the host:port target. When
+// job.SNIHostname is set, the line connects to job.IP via --ip= while sending
+// SNIHostname as the TLS servername, instead of sending job.IP as SNI.
+func targetLine(job ScanJob) string {
+	key := targetKey(job.IP, strconv.Itoa(job.Port))
+	if job.SNIHostname == "" {
+		return key
+	}
+	return fmt.Sprintf("--ip=%s %s", normalizeTargetHost(job.IP), targetKey(job.SNIHostname, strconv.Itoa(job.Port)))
 }
 
 func normalizeTargetHost(host string) string {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -57,9 +57,9 @@ func TestBatchScanStarttlsRouting(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		ip            string
-		wantSTARTTLS  string
-		wantPort      int
+		ip           string
+		wantSTARTTLS string
+		wantPort     int
 	}{
 		{"10.0.0.1", "", 443},
 		{"10.0.0.2", "postgres", 5432},
@@ -80,6 +80,75 @@ func TestBatchScanStarttlsRouting(t *testing.T) {
 		if r.result.Status != StatusOK {
 			t.Errorf("%s: Status = %s, want OK", tc.ip, r.result.Status)
 		}
+	}
+}
+
+func TestTargetLine(t *testing.T) {
+	tests := []struct {
+		name string
+		job  ScanJob
+		want string
+	}{
+		{
+			name: "no SNI override",
+			job:  ScanJob{IP: "10.0.0.1", Port: 443},
+			want: "10.0.0.1:443",
+		},
+		{
+			name: "SNI override connects via --ip and sends hostname as servername",
+			job:  ScanJob{IP: "10.0.0.1", Port: 443, SNIHostname: "gateway.example.com"},
+			want: "--ip=10.0.0.1 gateway.example.com:443",
+		},
+		{
+			name: "SNI override with IPv6 target",
+			job:  ScanJob{IP: "fd2e:6f44:5dd8:c956::16", Port: 8443, SNIHostname: "gateway.example.com"},
+			want: "--ip=fd2e:6f44:5dd8:c956::16 gateway.example.com:8443",
+		},
+		{
+			name: "IPv6 target without SNI override",
+			job:  ScanJob{IP: "fd2e:6f44:5dd8:c956::16", Port: 8443},
+			want: "[fd2e:6f44:5dd8:c956::16]:8443",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := targetLine(tt.job); got != tt.want {
+				t.Errorf("targetLine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestScanWithSNIHostnameOverride(t *testing.T) {
+	testutil.InstallMockTestSSL(t)
+
+	// The pod is only reachable at its cluster IP, but the service in front
+	// of it (e.g. an Envoy/Gateway API listener) routes by SNI, so the scan
+	// must present the expected hostname while still connecting to the IP.
+	jobs := []ScanJob{{IP: "10.0.0.5", Port: 443, SNIHostname: "gateway.example.com"}}
+	results := Scan(jobs, 1, nil, nil, testPolicy(t), DefaultScanTimeouts, nil)
+
+	if results.ScannedIPs != 1 {
+		t.Fatalf("expected 1 scanned IP, got %d", results.ScannedIPs)
+	}
+	if len(results.IPResults) != 1 {
+		t.Fatalf("expected 1 IP result, got %d", len(results.IPResults))
+	}
+
+	ir := results.IPResults[0]
+	if ir.IP != "10.0.0.5" {
+		t.Errorf("expected result attributed to connect IP 10.0.0.5, got %s", ir.IP)
+	}
+	if len(ir.PortResults) == 0 {
+		t.Fatalf("IP %s: no port results", ir.IP)
+	}
+	pr := ir.PortResults[0]
+	if pr.Status != StatusOK {
+		t.Errorf("expected status OK, got %s (%s)", pr.Status, pr.Reason)
+	}
+	if len(pr.TlsVersions) == 0 {
+		t.Errorf("expected TLS versions to be populated")
 	}
 }
 
@@ -147,7 +216,7 @@ func TestPerformClusterScanWithMockPods(t *testing.T) {
 		makePod("no-ports", "openshift-console", "10.128.0.30"),
 	}
 
-	results := PerformClusterScan(pods, 2, nil, testPolicy(t), DefaultScanTimeouts, nil, nil)
+	results := PerformClusterScan(pods, 2, nil, testPolicy(t), DefaultScanTimeouts, nil, nil, "")
 
 	if results.ScannedIPs != 3 {
 		t.Errorf("expected 3 scanned IPs (including no-ports), got %d", results.ScannedIPs)

--- a/internal/scanner/types.go
+++ b/internal/scanner/types.go
@@ -172,6 +172,13 @@ type ScanJob struct {
 	Port      int
 	Pod       k8s.PodInfo
 	Component *k8s.OpenshiftComponent
+	// SNIHostname, when non-empty, overrides the TLS SNI servername sent to
+	// this target. The connection is still made to IP:Port; testssl.sh is
+	// instructed to use SNIHostname as the servername via --ip=IP. This is
+	// for cases where a target must be reached by IP (e.g. an in-cluster pod
+	// IP) but the service in front of it (e.g. an Envoy/Gateway API listener)
+	// routes by SNI and rejects handshakes without the expected hostname.
+	SNIHostname string
 }
 
 type SkippedPort struct {

--- a/internal/testutil/mock_testssl.go
+++ b/internal/testutil/mock_testssl.go
@@ -11,6 +11,15 @@ import (
 // It reads a targets file and writes a JSON array of findings.
 // Set MOCK_NO_MLKEM=1 in the environment to suppress ML-KEM findings,
 // simulating a host that does not support post-quantum key exchange.
+//
+// Each line of the targets file is normally a bare "host:port" target, but
+// may instead start with "--ip=<ip> " followed by "hostname:port" (see
+// scanner.targetLine), mirroring how testssl.sh lets a caller connect to an
+// explicit IP while sending a different TLS SNI servername. Real testssl.sh
+// reports such targets as "ip": "<connect-ip>/<node>" in its JSON output; the
+// mock reproduces that so tests can verify results are still attributed to
+// the connect IP (see scanner.GroupTestSSLOutputByIPPort, which keys results
+// on the ip portion before the "/").
 const MockTestSSLScript = `#!/bin/bash
 JSONFILE=""
 TARGETS_FILE=""
@@ -29,14 +38,22 @@ SERVICE="https"
 printf '['
 FIRST=true
 while IFS= read -r target; do
-    ip="${target%%:*}"
-    port="${target##*:}"
+    ip=""
+    node_port="$target"
+    if [[ "$target" == --ip=* ]]; then
+        ip="${target%% *}"
+        ip="${ip#--ip=}"
+        node_port="${target#* }"
+    fi
+    node="${node_port%%:*}"
+    port="${node_port##*:}"
+    [ -z "$ip" ] && ip="$node"
     [ "$FIRST" = true ] && FIRST=false || printf ','
-    printf '{"id":"TLS1_2","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)","service":"%s"},' "$ip" "$ip" "$port" "$SERVICE"
-    printf '{"id":"TLS1_3","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)","service":"%s"},' "$ip" "$ip" "$port" "$SERVICE"
-    printf '{"id":"FS","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)","service":"%s"}' "$ip" "$ip" "$port" "$SERVICE"
+    printf '{"id":"TLS1_2","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)","service":"%s"},' "$ip" "$node" "$port" "$SERVICE"
+    printf '{"id":"TLS1_3","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)","service":"%s"},' "$ip" "$node" "$port" "$SERVICE"
+    printf '{"id":"FS","ip":"%s/%s","port":"%s","severity":"OK","finding":"offered (OK)","service":"%s"}' "$ip" "$node" "$port" "$SERVICE"
     if [ -z "${MOCK_NO_MLKEM:-}" ]; then
-        printf ',{"id":"FS_KEMs","ip":"%s/%s","port":"%s","severity":"OK","finding":"x25519mlkem768","service":"%s"}' "$ip" "$ip" "$port" "$SERVICE"
+        printf ',{"id":"FS_KEMs","ip":"%s/%s","port":"%s","severity":"OK","finding":"x25519mlkem768","service":"%s"}' "$ip" "$node" "$port" "$SERVICE"
     fi
 done < "$TARGETS_FILE"
 printf ']'


### PR DESCRIPTION
Gateway API tests requires requests with SNI headers. Currently the tls-scanner cannot make requests enforcing the hostname, not being able to detect that it is a TLS listener behind an envoy proxy and passing it.

This change adds the capability to specify what is the hostname of the endpoint being called, allowing the test to be properly executed