### PR TITLE
Add --exclude-labels flag to skip pods by label selector

### DIFF
--- a/cmd/tls-scanner/main.go
+++ b/cmd/tls-scanner/main.go
@@ -62,6 +62,7 @@ func run(args []string) (exitCode int) {
 	allPods := fs.Bool("all-pods", false, "Scan all pods in the cluster (overrides --host)")
 	componentFilter := fs.String("component-filter", "", "Filter pods by a comma-separated list of component names (only used with --all-pods)")
 	namespaceFilter := fs.String("namespace-filter", "", "Filter pods by a comma-separated list of namespaces (only used with --all-pods)")
+	excludeLabels := fs.String("exclude-labels", "", "Exclude pods matching a comma-separated list of label selectors, e.g. 'olm.catalogSource' or 'app=catalog,tier=frontend' (only used with --all-pods). A pod is excluded when ALL selectors match (AND semantics).")
 	targets := fs.String("targets", "", "A comma-separated list of host:port targets to scan")
 	templateFile := fs.String("template", "", "Path to a YAML file listing hosts and ports to scan (see --generate-template)")
 	generateTemplate := fs.String("generate-template", "", "Write a sample targets YAML template to this path and exit")
@@ -256,6 +257,7 @@ func run(args []string) (exitCode int) {
 		}
 		pods = client.FilterPodsByComponent(pods, *componentFilter)
 		pods = k8s.FilterPodsByNamespace(pods, *namespaceFilter)
+		pods = k8s.FilterPodsByExcludeLabels(pods, *excludeLabels)
 
 		if len(pods) == 0 {
 			slog.Warn("no pods found matching the given filters, nothing to scan")

--- a/internal/k8s/client.go
+++ b/internal/k8s/client.go
@@ -175,3 +175,67 @@ func FilterPodsByNamespace(pods []PodInfo, namespaceFilter string) []PodInfo {
 	slog.Info("filtered pods by namespace", "remaining", len(filtered), "total", len(pods))
 	return filtered
 }
+
+// FilterPodsByExcludeLabels removes pods whose labels match ALL of the
+// specified selectors. The excludeLabels string is a comma-separated list of
+// key=value pairs; a key without a value (e.g. "olm.catalogSource") matches
+// any pod that has that label regardless of its value.
+func FilterPodsByExcludeLabels(pods []PodInfo, excludeLabels string) []PodInfo {
+	if excludeLabels == "" {
+		return pods
+	}
+
+	slog.Info("filtering out pods by label selector", "excludeLabels", excludeLabels)
+
+	type labelSelector struct {
+		key   string
+		value string // empty means key-only match
+		hasValue bool
+	}
+
+	var selectors []labelSelector
+	for _, entry := range strings.Split(excludeLabels, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		if idx := strings.IndexByte(entry, '='); idx >= 0 {
+			selectors = append(selectors, labelSelector{key: entry[:idx], value: entry[idx+1:], hasValue: true})
+		} else {
+			selectors = append(selectors, labelSelector{key: entry})
+		}
+	}
+
+	if len(selectors) == 0 {
+		return pods
+	}
+
+	var filtered []PodInfo
+	for _, pod := range pods {
+		var labels map[string]string
+		if pod.Pod != nil {
+			labels = pod.Pod.Labels
+		}
+
+		exclude := true
+		for _, sel := range selectors {
+			v, ok := labels[sel.key]
+			if !ok {
+				exclude = false
+				break
+			}
+			if sel.hasValue && v != sel.value {
+				exclude = false
+				break
+			}
+		}
+		if exclude {
+			slog.Debug("excluding pod by label selector", "namespace", pod.Namespace, "pod", pod.Name, "excludeLabels", excludeLabels)
+			continue
+		}
+		filtered = append(filtered, pod)
+	}
+
+	slog.Info("filtered out pods by label selector", "remaining", len(filtered), "total", len(pods))
+	return filtered
+}

--- a/internal/k8s/filter_test.go
+++ b/internal/k8s/filter_test.go
@@ -1,11 +1,37 @@
 package k8s
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 func makePods(namespaces ...string) []PodInfo {
 	var pods []PodInfo
 	for _, ns := range namespaces {
 		pods = append(pods, PodInfo{Name: "pod-" + ns, Namespace: ns, IPs: []string{"10.0.0.1"}})
+	}
+	return pods
+}
+
+func makePodsWithLabels(labels ...map[string]string) []PodInfo {
+	var pods []PodInfo
+	for i, lbls := range labels {
+		pod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("pod-%d", i),
+				Namespace: "default",
+				Labels:    lbls,
+			},
+		}
+		pods = append(pods, PodInfo{
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+			IPs:       []string{"10.0.0.1"},
+			Pod:       pod,
+		})
 	}
 	return pods
 }
@@ -63,5 +89,76 @@ func TestFilterPodsByNamespaceWhitespace(t *testing.T) {
 	filtered := FilterPodsByNamespace(pods, " openshift-apiserver , openshift-etcd ")
 	if len(filtered) != 2 {
 		t.Fatalf("expected 2 pods (whitespace should be trimmed), got %d", len(filtered))
+	}
+}
+
+func TestFilterPodsByExcludeLabelsEmpty(t *testing.T) {
+	pods := makePodsWithLabels(
+		map[string]string{"olm.catalogSource": "redhat-ods-operator"},
+		map[string]string{"app": "my-operator"},
+	)
+
+	filtered := FilterPodsByExcludeLabels(pods, "")
+	if len(filtered) != 2 {
+		t.Errorf("empty exclude should return all pods: expected 2, got %d", len(filtered))
+	}
+}
+
+func TestFilterPodsByExcludeLabelsKeyOnly(t *testing.T) {
+	pods := makePodsWithLabels(
+		map[string]string{"olm.catalogSource": "redhat-ods-operator"},
+		map[string]string{"app": "my-operator"},
+	)
+
+	filtered := FilterPodsByExcludeLabels(pods, "olm.catalogSource")
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 pod after excluding by key, got %d", len(filtered))
+	}
+	if filtered[0].Pod.Labels["app"] != "my-operator" {
+		t.Errorf("wrong pod kept: %v", filtered[0].Pod.Labels)
+	}
+}
+
+func TestFilterPodsByExcludeLabelsKeyValue(t *testing.T) {
+	pods := makePodsWithLabels(
+		map[string]string{"olm.catalogSource": "redhat-ods-operator"},
+		map[string]string{"olm.catalogSource": "community-operators"},
+		map[string]string{"app": "my-operator"},
+	)
+
+	filtered := FilterPodsByExcludeLabels(pods, "olm.catalogSource=redhat-ods-operator")
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 pods, got %d", len(filtered))
+	}
+	for _, p := range filtered {
+		if v := p.Pod.Labels["olm.catalogSource"]; v == "redhat-ods-operator" {
+			t.Errorf("excluded pod leaked through: %v", p.Pod.Labels)
+		}
+	}
+}
+
+func TestFilterPodsByExcludeLabelsMultipleSelectors(t *testing.T) {
+	pods := makePodsWithLabels(
+		map[string]string{"olm.catalogSource": "rhods", "tier": "catalog"},
+		map[string]string{"olm.catalogSource": "rhods"},
+		map[string]string{"app": "my-operator"},
+	)
+
+	// Only exclude pods that have BOTH labels.
+	filtered := FilterPodsByExcludeLabels(pods, "olm.catalogSource,tier=catalog")
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 pods (AND semantics), got %d", len(filtered))
+	}
+}
+
+func TestFilterPodsByExcludeLabelsNilPod(t *testing.T) {
+	pods := []PodInfo{
+		{Name: "no-pod-ref", Namespace: "default", IPs: []string{"10.0.0.1"}},
+	}
+
+	// Should not panic; pod with nil Pod field has no labels so it is kept.
+	filtered := FilterPodsByExcludeLabels(pods, "olm.catalogSource")
+	if len(filtered) != 1 {
+		t.Errorf("expected pod with nil Pod ref to be kept, got %d pods", len(filtered))
 	}
 }


### PR DESCRIPTION
## Problem

When using `--all-pods`, the scanner has no way to skip pods that are known to serve plain (non-TLS) traffic. A concrete case: OLM installs a catalog source pod in the same namespace as the operator. That pod serves plain gRPC (port 50051) and will always fail TLS compliance checks.

The current workaround used in some CI jobs is to delete the CatalogSource before scanning:

```bash
oc delete catalogsource --all -n redhat-ods-operator --ignore-not-found
oc wait --for=delete pod -l olm.catalogSource -n redhat-ods-operator --timeout=60s || true
```

This is functional but destructive. The deletion can cause side effects on CI jobs that need OLM to remain intact for later steps.

## Solution

Add a `--exclude-labels` flag that filters out pods matching a comma-separated list of label selectors before scanning. A pod is excluded only when **all** selectors match (AND semantics).

Selector syntax:
- Key-only: `olm.catalogSource` — excludes any pod that has this label, regardless of value
- Key=value: `app=catalog` — excludes pods where the label has that exact value
- Combined: `olm.catalogSource,tier=catalog` — excludes pods that have both

The flag is a no-op when empty and only applies with `--all-pods`, consistent with `--namespace-filter` and `--component-filter`.

## Example

```bash
# Exclude OLM catalog pods from the scan
tls-scanner --all-pods \
  --namespace-filter redhat-ods-operator,redhat-ods-applications \
  --exclude-labels olm.catalogSource
```

## Changes

- `internal/k8s/client.go`: add `FilterPodsByExcludeLabels` (package-level function, mirrors `FilterPodsByNamespace` pattern)
- `internal/k8s/filter_test.go`: add 5 test cases covering empty input, key-only match, key=value match, AND semantics, and nil `Pod` field
- `cmd/tls-scanner/main.go`: add `--exclude-labels` flag, wire it after namespace filter in the `--all-pods` path