### PR TITLE
DPTP-5126: Emit stable JUnit test names keyed by workload

### DIFF
--- a/internal/k8s/workload.go
+++ b/internal/k8s/workload.go
@@ -1,0 +1,65 @@
+package k8s
+
+import (
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// WorkloadIdentity is a run-stable identity for the workload that owns a pod.
+// Pod names embed per-run randomness (ReplicaSet pod-template hashes, random
+// suffixes, node names containing the cluster ID), so results keyed by pod
+// name cannot be aggregated across CI runs. The owning workload's identity is
+// the same on every run of the same payload.
+type WorkloadIdentity struct {
+	Kind string
+	Name string
+}
+
+func (w WorkloadIdentity) String() string {
+	return w.Kind + "/" + w.Name
+}
+
+// WorkloadIdentityForPod resolves the stable workload identity for a pod
+// using only data already present on the pod object (owner references,
+// labels, node name), so it needs no API round-trips.
+func WorkloadIdentityForPod(pod *v1.Pod) WorkloadIdentity {
+	if pod == nil {
+		return WorkloadIdentity{Kind: "pod", Name: "unknown"}
+	}
+
+	if owner := metav1.GetControllerOf(pod); owner != nil {
+		switch owner.Kind {
+		case "ReplicaSet":
+			// Deployment-owned ReplicaSets are named "<deployment>-<pod-template-hash>".
+			if hash := pod.Labels["pod-template-hash"]; hash != "" {
+				if name, ok := strings.CutSuffix(owner.Name, "-"+hash); ok {
+					return WorkloadIdentity{Kind: "deployment", Name: name}
+				}
+			}
+			return WorkloadIdentity{Kind: "replicaset", Name: owner.Name}
+		case "DaemonSet", "StatefulSet", "Job":
+			return WorkloadIdentity{Kind: strings.ToLower(owner.Kind), Name: owner.Name}
+		case "Node":
+			// Static (mirror) pods are named "<manifest name>-<node name>".
+			return WorkloadIdentity{Kind: "staticpod", Name: trimNodeSuffix(pod.Name, pod.Spec.NodeName)}
+		default:
+			return WorkloadIdentity{Kind: strings.ToLower(owner.Kind), Name: owner.Name}
+		}
+	}
+
+	// Unowned per-node pods (guard pods, installer and revision-pruner pods)
+	// embed the node name, which contains the per-run cluster ID; strip it.
+	return WorkloadIdentity{Kind: "pod", Name: trimNodeSuffix(pod.Name, pod.Spec.NodeName)}
+}
+
+func trimNodeSuffix(podName, nodeName string) string {
+	if nodeName == "" {
+		return podName
+	}
+	if name, ok := strings.CutSuffix(podName, "-"+nodeName); ok {
+		return name
+	}
+	return podName
+}

--- a/internal/k8s/workload_test.go
+++ b/internal/k8s/workload_test.go
@@ -1,0 +1,130 @@
+package k8s
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func controllerRef(kind, name string) metav1.OwnerReference {
+	isController := true
+	return metav1.OwnerReference{Kind: kind, Name: name, Controller: &isController}
+}
+
+// Pod name shapes are taken from real CI scan results; every identity must be
+// free of per-run randomness (hashes, random suffixes, node/cluster names).
+func TestWorkloadIdentityForPod(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		testName string
+		pod      *v1.Pod
+		want     string
+	}{
+		{
+			testName: "nil pod",
+			pod:      nil,
+			want:     "pod/unknown",
+		},
+		{
+			testName: "deployment pod via replicaset with pod-template-hash",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "networking-console-plugin-54fdc79fd7-r2rk6",
+					Labels:          map[string]string{"pod-template-hash": "54fdc79fd7"},
+					OwnerReferences: []metav1.OwnerReference{controllerRef("ReplicaSet", "networking-console-plugin-54fdc79fd7")},
+				},
+			},
+			want: "deployment/networking-console-plugin",
+		},
+		{
+			testName: "replicaset pod without pod-template-hash",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "standalone-rs-abcde",
+					OwnerReferences: []metav1.OwnerReference{controllerRef("ReplicaSet", "standalone-rs")},
+				},
+			},
+			want: "replicaset/standalone-rs",
+		},
+		{
+			testName: "daemonset pod",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "dns-default-6lmw2",
+					OwnerReferences: []metav1.OwnerReference{controllerRef("DaemonSet", "dns-default")},
+				},
+			},
+			want: "daemonset/dns-default",
+		},
+		{
+			testName: "statefulset pod",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "prometheus-k8s-0",
+					OwnerReferences: []metav1.OwnerReference{controllerRef("StatefulSet", "prometheus-k8s")},
+				},
+			},
+			want: "statefulset/prometheus-k8s",
+		},
+		{
+			testName: "static pod strips node name",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "etcd-ci-op-2677f6r3-83e8e-h9f6h-master-0",
+					OwnerReferences: []metav1.OwnerReference{controllerRef("Node", "ci-op-2677f6r3-83e8e-h9f6h-master-0")},
+				},
+				Spec: v1.PodSpec{NodeName: "ci-op-2677f6r3-83e8e-h9f6h-master-0"},
+			},
+			want: "staticpod/etcd",
+		},
+		{
+			testName: "job pod",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "collect-profiles-29135430-abcde",
+					OwnerReferences: []metav1.OwnerReference{controllerRef("Job", "collect-profiles-29135430")},
+				},
+			},
+			want: "job/collect-profiles-29135430",
+		},
+		{
+			testName: "unowned guard pod strips node name",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kube-apiserver-guard-ci-op-2677f6r3-83e8e-h9f6h-master-1",
+				},
+				Spec: v1.PodSpec{NodeName: "ci-op-2677f6r3-83e8e-h9f6h-master-1"},
+			},
+			want: "pod/kube-apiserver-guard",
+		},
+		{
+			testName: "unowned pod whose name does not embed the node name",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "some-standalone-pod"},
+				Spec:       v1.PodSpec{NodeName: "worker-1"},
+			},
+			want: "pod/some-standalone-pod",
+		},
+		{
+			testName: "unknown controller kind",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "redhat-operators-td4zz",
+					OwnerReferences: []metav1.OwnerReference{controllerRef("CatalogSource", "redhat-operators")},
+				},
+			},
+			want: "catalogsource/redhat-operators",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.testName, func(t *testing.T) {
+			t.Parallel()
+			if got := WorkloadIdentityForPod(tc.pod).String(); got != tc.want {
+				t.Errorf("WorkloadIdentityForPod() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/output/junit.go
+++ b/internal/output/junit.go
@@ -5,16 +5,24 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
+	"github.com/openshift/tls-scanner/internal/k8s"
 	"github.com/openshift/tls-scanner/internal/scanner"
 )
+
+// tlsAdherenceGate tags adherence testcases so the feature-gate promotion
+// tooling (openshift/api) can match them to the TLSAdherence gate. It must
+// appear verbatim in every test name that provides promotion evidence.
+const tlsAdherenceGate = "[OCPFeatureGate:TLSAdherence]"
 
 type JUnitTestSuite struct {
 	XMLName    xml.Name        `xml:"testsuite"`
 	Name       string          `xml:"name,attr"`
 	Tests      int             `xml:"tests,attr"`
 	Failures   int             `xml:"failures,attr"`
+	Skipped    int             `xml:"skipped,attr,omitempty"`
 	Time       float64         `xml:"time,attr"`
 	Properties []JUnitProperty `xml:"properties>property,omitempty"`
 	TestCases  []JUnitTestCase `xml:"testcase"`
@@ -26,6 +34,7 @@ type JUnitTestCase struct {
 	ClassName string        `xml:"classname,attr"`
 	Time      float64       `xml:"time,attr"`
 	Failure   *JUnitFailure `xml:"failure,omitempty"`
+	Skipped   *JUnitSkipped `xml:"skipped,omitempty"`
 	SystemOut string        `xml:"system-out,omitempty"`
 	SystemErr string        `xml:"system-err,omitempty"`
 }
@@ -37,9 +46,51 @@ type JUnitFailure struct {
 	Content string   `xml:",chardata"`
 }
 
+type JUnitSkipped struct {
+	XMLName xml.Name `xml:"skipped"`
+	Message string   `xml:"message,attr"`
+}
+
 type JUnitProperty struct {
 	Name  string `xml:"name,attr"`
 	Value string `xml:"value,attr"`
+}
+
+// endpointGroup aggregates every scanned pod endpoint that belongs to the
+// same workload and port. JUnit testcases are emitted per group, not per
+// pod, so the set of test names does not change with replica counts,
+// scheduling, or pod-name randomness between runs.
+type endpointGroup struct {
+	subject   string // stable test-name fragment, e.g. "ns/openshift-dns daemonset/dns-default port/5353"
+	className string
+	failures  []string
+	skips     []string
+	scanned   []string
+}
+
+// groupSubject returns the stable identity fragment used in test names. IPs
+// and pod names must not appear here; they change on every run.
+func groupSubject(ipResult scanner.IPResult, port int) (subject, className string) {
+	if ipResult.Pod != nil {
+		workload := k8s.WorkloadIdentityForPod(ipResult.Pod.Pod)
+		if workload.Name == "unknown" && ipResult.Pod.Name != "" {
+			workload.Name = ipResult.Pod.Name
+		}
+		subject = fmt.Sprintf("ns/%s %s port/%d", ipResult.Pod.Namespace, workload, port)
+		className = fmt.Sprintf("%s/%s", ipResult.Pod.Namespace, workload)
+		return subject, className
+	}
+	// No pod metadata: fall back to the IP. Such entries cannot be stable
+	// across runs, but they should not occur in pod-driven scans.
+	return fmt.Sprintf("host/%s port/%d", ipResult.IP, port), ipResult.IP
+}
+
+func endpointDescription(ipResult scanner.IPResult, portResult scanner.PortResult) string {
+	podName := ipResult.IP
+	if ipResult.Pod != nil {
+		podName = ipResult.Pod.Name
+	}
+	return fmt.Sprintf("pod %s (%s:%d)", podName, ipResult.IP, portResult.Port)
 }
 
 func WriteJUnitOutput(scanResults scanner.ScanResults, filename string, pqcCheck bool) error {
@@ -49,29 +100,33 @@ func WriteJUnitOutput(scanResults scanner.ScanResults, filename string, pqcCheck
 
 	enforceTLSCompliance := scanner.TLSConfigComplianceFailuresEnforced(scanResults)
 
+	groups := map[string]*endpointGroup{}
+	var groupOrder []string
+
 	for _, ipResult := range scanResults.IPResults {
 		for _, portResult := range ipResult.PortResults {
-			className := ipResult.IP
-			if ipResult.Pod != nil {
-				className = ipResult.Pod.Name
+			// Ports with no external TLS surface produce no testcase:
+			// pods without listeners, localhost-only listeners, and
+			// plaintext health-probe ports are not scannable endpoints.
+			if portResult.Status == scanner.StatusNoPorts ||
+				portResult.Status == scanner.StatusLocalhostOnly ||
+				portResult.Status == scanner.StatusProbePort {
+				continue
 			}
 
-			namePrefix := "[TLS Profile] "
-			if pqcCheck {
-				namePrefix = "[PQC] "
+			subject, className := groupSubject(ipResult, portResult.Port)
+			group, ok := groups[subject]
+			if !ok {
+				group = &endpointGroup{subject: subject, className: className}
+				groups[subject] = group
+				groupOrder = append(groupOrder, subject)
 			}
 
-			testCase := JUnitTestCase{
-				Name:      fmt.Sprintf("%s%s:%d - %s", namePrefix, ipResult.IP, portResult.Port, portResult.Service),
-				ClassName: className,
-			}
+			endpoint := endpointDescription(ipResult, portResult)
 
 			var failures []string
 			if pqcCheck {
-				if portResult.Status != scanner.StatusNoPorts &&
-					portResult.Status != scanner.StatusLocalhostOnly &&
-					portResult.Status != scanner.StatusNoTLS &&
-					portResult.Status != scanner.StatusProbePort {
+				if portResult.Status == scanner.StatusOK {
 					if !portResult.TLS13Supported {
 						failures = append(failures, "PQC: TLS 1.3 not supported.")
 					}
@@ -79,31 +134,73 @@ func WriteJUnitOutput(scanResults scanner.ScanResults, filename string, pqcCheck
 						failures = append(failures, "PQC: ML-KEM not supported (no x25519mlkem768 or mlkem768).")
 					}
 				}
-			} else {
-				if enforceTLSCompliance {
-					if portResult.IngressTLSConfigCompliance != nil && !scanner.IsTLSConfigCompliant(portResult.IngressTLSConfigCompliance) {
-						failures = append(failures, "Ingress TLS config is not compliant.")
-					}
-					if portResult.APIServerTLSConfigCompliance != nil && !scanner.IsTLSConfigCompliant(portResult.APIServerTLSConfigCompliance) {
-						failures = append(failures, "API Server TLS config is not compliant.")
-					}
-					if portResult.KubeletTLSConfigCompliance != nil && !scanner.IsTLSConfigCompliant(portResult.KubeletTLSConfigCompliance) {
-						failures = append(failures, "Kubelet TLS config is not compliant.")
-					}
+			} else if enforceTLSCompliance {
+				if portResult.IngressTLSConfigCompliance != nil && !scanner.IsTLSConfigCompliant(portResult.IngressTLSConfigCompliance) {
+					failures = append(failures, "Ingress TLS config is not compliant.")
+				}
+				if portResult.APIServerTLSConfigCompliance != nil && !scanner.IsTLSConfigCompliant(portResult.APIServerTLSConfigCompliance) {
+					failures = append(failures, "API Server TLS config is not compliant.")
+				}
+				if portResult.KubeletTLSConfigCompliance != nil && !scanner.IsTLSConfigCompliant(portResult.KubeletTLSConfigCompliance) {
+					failures = append(failures, "Kubelet TLS config is not compliant.")
 				}
 			}
 
-			if len(failures) > 0 {
-				testCase.Failure = &JUnitFailure{
-					Message: "TLS Compliance Failed",
-					Type:    "TLSComplianceCheck",
-					Content: strings.Join(failures, "\n"),
+			switch {
+			case len(failures) > 0:
+				group.failures = append(group.failures, fmt.Sprintf("%s: %s", endpoint, strings.Join(failures, " ")))
+			case portResult.Status == scanner.StatusOK:
+				group.scanned = append(group.scanned, endpoint)
+			default:
+				reason := portResult.Reason
+				if reason == "" {
+					reason = string(portResult.Status)
 				}
-				testSuite.Failures++
+				group.skips = append(group.skips, fmt.Sprintf("%s: %s", endpoint, reason))
 			}
-
-			testSuite.TestCases = append(testSuite.TestCases, testCase)
 		}
+	}
+
+	namePrefix := "[sig-security] "
+	checkDescription := "TLS profile scan"
+	if pqcCheck {
+		checkDescription = "should be PQC ready with TLS 1.3 and ML-KEM"
+	} else if enforceTLSCompliance {
+		namePrefix = "[sig-security]" + tlsAdherenceGate + " "
+		checkDescription = "should comply with the cluster TLS profile"
+	}
+
+	sort.Strings(groupOrder)
+	for _, subject := range groupOrder {
+		group := groups[subject]
+
+		testCase := JUnitTestCase{
+			Name:      fmt.Sprintf("%s%s %s", namePrefix, group.subject, checkDescription),
+			ClassName: group.className,
+		}
+
+		switch {
+		case len(group.failures) > 0:
+			testCase.Failure = &JUnitFailure{
+				Message: "TLS Compliance Failed",
+				Type:    "TLSComplianceCheck",
+				Content: strings.Join(group.failures, "\n"),
+			}
+			testSuite.Failures++
+		case len(group.scanned) == 0:
+			// Every endpoint of this workload/port was unreachable for a
+			// TLS handshake (e.g. blocked by NetworkPolicy) or served no
+			// TLS. Skipping instead of passing keeps unverified endpoints
+			// from counting as evidence that the check succeeded.
+			testCase.Skipped = &JUnitSkipped{
+				Message: strings.Join(group.skips, "; "),
+			}
+			testSuite.Skipped++
+		default:
+			testCase.SystemOut = strings.Join(append(group.scanned, group.skips...), "\n")
+		}
+
+		testSuite.TestCases = append(testSuite.TestCases, testCase)
 	}
 
 	testSuite.Tests = len(testSuite.TestCases)

--- a/internal/output/junit_test.go
+++ b/internal/output/junit_test.go
@@ -4,9 +4,12 @@ import (
 	"encoding/xml"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	configv1 "github.com/openshift/api/config/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/tls-scanner/internal/k8s"
 	"github.com/openshift/tls-scanner/internal/scanner"
@@ -23,6 +26,40 @@ func readJUnitSuite(t *testing.T, path string) JUnitTestSuite {
 		t.Fatalf("invalid XML: %v", err)
 	}
 	return suite
+}
+
+func deploymentPodInfo(deployment, hash, suffix, namespace string) *k8s.PodInfo {
+	isController := true
+	name := deployment + "-" + hash + "-" + suffix
+	return &k8s.PodInfo{
+		Name:      name,
+		Namespace: namespace,
+		Pod: &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels:    map[string]string{"pod-template-hash": hash},
+				OwnerReferences: []metav1.OwnerReference{{
+					Kind:       "ReplicaSet",
+					Name:       deployment + "-" + hash,
+					Controller: &isController,
+				}},
+			},
+		},
+	}
+}
+
+func strictScanResults(ipResults ...scanner.IPResult) scanner.ScanResults {
+	return scanner.ScanResults{
+		TLSSecurityConfig: &k8s.TLSSecurityProfile{
+			TLSAdherence: configv1.TLSAdherencePolicyStrictAllComponents,
+			APIServer: &k8s.APIServerTLSProfile{
+				Type:          "Modern",
+				MinTLSVersion: "VersionTLS13",
+			},
+		},
+		IPResults: ipResults,
+	}
 }
 
 func TestWriteJUnitOutputBasic(t *testing.T) {
@@ -77,6 +114,9 @@ func TestWriteJUnitOutputPQCFailures(t *testing.T) {
 	if suite.TestCases[0].Failure == nil {
 		t.Fatal("expected failure on PQC non-compliant port")
 	}
+	if strings.Contains(suite.TestCases[0].Name, tlsAdherenceGate) {
+		t.Errorf("PQC test name %q must not carry the TLSAdherence gate tag", suite.TestCases[0].Name)
+	}
 }
 
 func TestWriteJUnitOutputPQCPass(t *testing.T) {
@@ -115,10 +155,10 @@ func TestWriteJUnitOutputSkippableStatuses(t *testing.T) {
 			IP:     "10.0.0.1",
 			Status: "scanned",
 			PortResults: []scanner.PortResult{
-				{Port: 1, Status: scanner.StatusNoPorts, TLS13Supported: false, MLKEMSupported: false},
-				{Port: 2, Status: scanner.StatusLocalhostOnly, TLS13Supported: false, MLKEMSupported: false},
-				{Port: 3, Status: scanner.StatusNoTLS, TLS13Supported: false, MLKEMSupported: false},
-				{Port: 4, Status: scanner.StatusProbePort, TLS13Supported: false, MLKEMSupported: false},
+				{Port: 1, Status: scanner.StatusNoPorts},
+				{Port: 2, Status: scanner.StatusLocalhostOnly},
+				{Port: 3, Status: scanner.StatusNoTLS},
+				{Port: 4, Status: scanner.StatusProbePort},
 			},
 		}},
 	}
@@ -132,37 +172,35 @@ func TestWriteJUnitOutputSkippableStatuses(t *testing.T) {
 	if suite.Failures != 0 {
 		t.Errorf("Failures = %d, want 0 for skippable statuses", suite.Failures)
 	}
-	if suite.Tests != 4 {
-		t.Errorf("Tests = %d, want 4", suite.Tests)
+	// No-port, localhost-only, and probe-port entries have no external TLS
+	// surface and emit no testcase; the NO_TLS port is reported as skipped.
+	if suite.Tests != 1 {
+		t.Errorf("Tests = %d, want 1", suite.Tests)
+	}
+	if suite.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", suite.Skipped)
+	}
+	if suite.TestCases[0].Skipped == nil {
+		t.Error("expected NO_TLS endpoint to be reported as skipped")
 	}
 }
 
 func TestWriteJUnitOutputTLSComplianceFailure(t *testing.T) {
 	t.Parallel()
 
-	results := scanner.ScanResults{
-		TLSSecurityConfig: &k8s.TLSSecurityProfile{
-			TLSAdherence: configv1.TLSAdherencePolicyStrictAllComponents,
-			APIServer: &k8s.APIServerTLSProfile{
-				Type:          "Intermediate",
-				MinTLSVersion: "VersionTLS12",
-				Ciphers:       []string{"TLS_AES_128_GCM_SHA256"},
+	results := strictScanResults(scanner.IPResult{
+		IP:     "10.0.0.1",
+		Status: "scanned",
+		PortResults: []scanner.PortResult{{
+			Port:     443,
+			Protocol: "tcp",
+			Status:   scanner.StatusOK,
+			IngressTLSConfigCompliance: &scanner.TLSConfigComplianceResult{
+				Version: false,
+				Ciphers: true,
 			},
-		},
-		IPResults: []scanner.IPResult{{
-			IP:     "10.0.0.1",
-			Status: "scanned",
-			PortResults: []scanner.PortResult{{
-				Port:     443,
-				Protocol: "tcp",
-				Status:   scanner.StatusOK,
-				IngressTLSConfigCompliance: &scanner.TLSConfigComplianceResult{
-					Version: false,
-					Ciphers: true,
-				},
-			}},
 		}},
-	}
+	})
 
 	path := filepath.Join(t.TempDir(), "compliance.xml")
 	if err := WriteJUnitOutput(results, path, false); err != nil {
@@ -172,6 +210,196 @@ func TestWriteJUnitOutputTLSComplianceFailure(t *testing.T) {
 	suite := readJUnitSuite(t, path)
 	if suite.Failures != 1 {
 		t.Errorf("Failures = %d, want 1", suite.Failures)
+	}
+}
+
+func TestWriteJUnitOutputStableNamesAcrossRuns(t *testing.T) {
+	t.Parallel()
+
+	// The same deployment endpoint observed in two runs with different pod
+	// hashes, pod suffixes, and IPs must produce identical test names.
+	runs := []scanner.IPResult{
+		{
+			IP:     "10.128.2.14",
+			Status: "scanned",
+			Pod:    deploymentPodInfo("networking-console-plugin", "544b86b7cd", "qp9lp", "openshift-network-console"),
+			PortResults: []scanner.PortResult{{
+				Port:   9443,
+				Status: scanner.StatusOK,
+				APIServerTLSConfigCompliance: &scanner.TLSConfigComplianceResult{
+					Version: true,
+					Ciphers: false,
+				},
+			}},
+		},
+		{
+			IP:     "10.131.0.6",
+			Status: "scanned",
+			Pod:    deploymentPodInfo("networking-console-plugin", "54fdc79fd7", "r2rk6", "openshift-network-console"),
+			PortResults: []scanner.PortResult{{
+				Port:   9443,
+				Status: scanner.StatusOK,
+				APIServerTLSConfigCompliance: &scanner.TLSConfigComplianceResult{
+					Version: true,
+					Ciphers: false,
+				},
+			}},
+		},
+	}
+
+	var names []string
+	for i, ipResult := range runs {
+		path := filepath.Join(t.TempDir(), "run.xml")
+		if err := WriteJUnitOutput(strictScanResults(ipResult), path, false); err != nil {
+			t.Fatalf("WriteJUnitOutput run %d returned error: %v", i, err)
+		}
+		suite := readJUnitSuite(t, path)
+		if suite.Tests != 1 {
+			t.Fatalf("run %d: Tests = %d, want 1", i, suite.Tests)
+		}
+		names = append(names, suite.TestCases[0].Name)
+	}
+
+	if names[0] != names[1] {
+		t.Errorf("test names differ across runs:\n  %q\n  %q", names[0], names[1])
+	}
+	want := "[sig-security][OCPFeatureGate:TLSAdherence] ns/openshift-network-console deployment/networking-console-plugin port/9443 should comply with the cluster TLS profile"
+	if names[0] != want {
+		t.Errorf("test name = %q, want %q", names[0], want)
+	}
+}
+
+func TestWriteJUnitOutputAggregatesReplicas(t *testing.T) {
+	t.Parallel()
+
+	// One replica scanned clean, one failing, one unreachable: a single
+	// testcase is emitted for the workload and it fails.
+	results := strictScanResults(
+		scanner.IPResult{
+			IP:     "10.128.2.14",
+			Status: "scanned",
+			Pod:    deploymentPodInfo("router-default", "ddc8bbfc7", "mrf94", "openshift-ingress"),
+			PortResults: []scanner.PortResult{{
+				Port:   8443,
+				Status: scanner.StatusOK,
+				APIServerTLSConfigCompliance: &scanner.TLSConfigComplianceResult{
+					Version: true,
+					Ciphers: true,
+				},
+			}},
+		},
+		scanner.IPResult{
+			IP:     "10.131.0.6",
+			Status: "scanned",
+			Pod:    deploymentPodInfo("router-default", "ddc8bbfc7", "dv9wb", "openshift-ingress"),
+			PortResults: []scanner.PortResult{{
+				Port:   8443,
+				Status: scanner.StatusOK,
+				APIServerTLSConfigCompliance: &scanner.TLSConfigComplianceResult{
+					Version: false,
+					Ciphers: false,
+				},
+			}},
+		},
+		scanner.IPResult{
+			IP:     "10.129.2.7",
+			Status: "scanned",
+			Pod:    deploymentPodInfo("router-default", "ddc8bbfc7", "zz9zz", "openshift-ingress"),
+			PortResults: []scanner.PortResult{{
+				Port:   8443,
+				Status: scanner.StatusNoTLS,
+				Reason: "Port open but no TLS detected",
+			}},
+		},
+	)
+
+	path := filepath.Join(t.TempDir(), "aggregate.xml")
+	if err := WriteJUnitOutput(results, path, false); err != nil {
+		t.Fatalf("WriteJUnitOutput returned error: %v", err)
+	}
+
+	suite := readJUnitSuite(t, path)
+	if suite.Tests != 1 {
+		t.Fatalf("Tests = %d, want 1 aggregated testcase, got names: %v", suite.Tests, suite.TestCases)
+	}
+	if suite.Failures != 1 {
+		t.Errorf("Failures = %d, want 1", suite.Failures)
+	}
+	failure := suite.TestCases[0].Failure
+	if failure == nil {
+		t.Fatal("expected aggregated testcase to fail when any replica fails")
+	}
+	if !strings.Contains(failure.Content, "router-default-ddc8bbfc7-dv9wb") {
+		t.Errorf("failure content should identify the failing pod, got: %q", failure.Content)
+	}
+}
+
+func TestWriteJUnitOutputSkipsUnreachableWorkload(t *testing.T) {
+	t.Parallel()
+
+	// Every replica unreachable for a TLS handshake (e.g. NetworkPolicy
+	// blocks the scanner): the testcase must be skipped, not passed.
+	results := strictScanResults(scanner.IPResult{
+		IP:     "10.129.2.7",
+		Status: "scanned",
+		Pod:    deploymentPodInfo("networking-console-plugin", "54fdc79fd7", "vvs2b", "openshift-network-console"),
+		PortResults: []scanner.PortResult{{
+			Port:   9443,
+			Status: scanner.StatusNoTLS,
+			Reason: "Port open but no TLS detected",
+		}},
+	})
+
+	path := filepath.Join(t.TempDir(), "unreachable.xml")
+	if err := WriteJUnitOutput(results, path, false); err != nil {
+		t.Fatalf("WriteJUnitOutput returned error: %v", err)
+	}
+
+	suite := readJUnitSuite(t, path)
+	if suite.Tests != 1 || suite.Skipped != 1 || suite.Failures != 0 {
+		t.Fatalf("Tests/Skipped/Failures = %d/%d/%d, want 1/1/0", suite.Tests, suite.Skipped, suite.Failures)
+	}
+	if suite.TestCases[0].Skipped == nil {
+		t.Fatal("expected skipped element on unreachable workload")
+	}
+	if !strings.Contains(suite.TestCases[0].Skipped.Message, "no TLS detected") {
+		t.Errorf("skip message should carry the reason, got %q", suite.TestCases[0].Skipped.Message)
+	}
+}
+
+func TestWriteJUnitOutputGateTagOnlyWhenEnforced(t *testing.T) {
+	t.Parallel()
+
+	ipResult := scanner.IPResult{
+		IP:     "10.0.0.1",
+		Status: "scanned",
+		Pod:    deploymentPodInfo("console", "754974bc6f", "dml4t", "openshift-console"),
+		PortResults: []scanner.PortResult{{
+			Port:   8443,
+			Status: scanner.StatusOK,
+		}},
+	}
+
+	enforced := strictScanResults(ipResult)
+	notEnforced := scanner.ScanResults{IPResults: []scanner.IPResult{ipResult}}
+
+	enforcedPath := filepath.Join(t.TempDir(), "enforced.xml")
+	if err := WriteJUnitOutput(enforced, enforcedPath, false); err != nil {
+		t.Fatalf("WriteJUnitOutput returned error: %v", err)
+	}
+	notEnforcedPath := filepath.Join(t.TempDir(), "not-enforced.xml")
+	if err := WriteJUnitOutput(notEnforced, notEnforcedPath, false); err != nil {
+		t.Fatalf("WriteJUnitOutput returned error: %v", err)
+	}
+
+	enforcedName := readJUnitSuite(t, enforcedPath).TestCases[0].Name
+	notEnforcedName := readJUnitSuite(t, notEnforcedPath).TestCases[0].Name
+
+	if !strings.Contains(enforcedName, tlsAdherenceGate) {
+		t.Errorf("enforced test name %q should contain %q", enforcedName, tlsAdherenceGate)
+	}
+	if strings.Contains(notEnforcedName, tlsAdherenceGate) {
+		t.Errorf("non-enforced test name %q must not contain %q", notEnforcedName, tlsAdherenceGate)
 	}
 }
 
@@ -201,8 +429,8 @@ func TestWriteJUnitOutputUsesClassNameFromPod(t *testing.T) {
 	}
 
 	suite := readJUnitSuite(t, path)
-	if suite.TestCases[0].ClassName != "pod-a" {
-		t.Errorf("ClassName = %q, want %q (from pod name)", suite.TestCases[0].ClassName, "pod-a")
+	if suite.TestCases[0].ClassName != "ns-a/pod/pod-a" {
+		t.Errorf("ClassName = %q, want %q", suite.TestCases[0].ClassName, "ns-a/pod/pod-a")
 	}
 }
 


### PR DESCRIPTION
- Adds stable names to juint tests. 
- Adds a [OCPFeatureGate:TLSAdherence] tag for promotion tooling
- Labels skipped (exempt) entries as "skipped" instead of a passing signal.